### PR TITLE
feat: add weekly rewards experience

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,6 +15,7 @@ import { AuthProvider } from "@/services/auth/AuthProvider";
 import { CartProvider } from "@/context/CartContext";
 import { CouponProvider } from "@/context/CouponContext";
 import { WelcomeCouponModal } from "@/features/coupons/WelcomeCouponModal";
+import { SpinNudgeSheet } from "@/features/rewards/SpinNudgeSheet";
 import { ErrorBoundary } from "@/components/feedback/ErrorBoundary";
 import { colors } from "@/theme";
 
@@ -72,6 +73,9 @@ export default function RootLayout() {
                     </Stack>
                     {/* App-wide overlay: welcome-coupon prompt after login. */}
                     <WelcomeCouponModal />
+                    {/* App-wide overlay: weekly-spin nudge, once per launch
+                        (defers to the welcome prompt on first login). */}
+                    <SpinNudgeSheet />
                   </View>
                 </CouponProvider>
               </CartProvider>

--- a/app/beloningar.tsx
+++ b/app/beloningar.tsx
@@ -1,0 +1,4 @@
+import { RewardsScreen } from "@/features/rewards/RewardsScreen";
+
+/** Veckans Belöning — thin route re-export (features/README.md convention). */
+export default RewardsScreen;

--- a/app/poang.tsx
+++ b/app/poang.tsx
@@ -1,0 +1,4 @@
+import { PointsScreen } from "@/features/points/PointsScreen";
+
+/** Nutri-poäng — thin route re-export (features/README.md convention). */
+export default PointsScreen;

--- a/components/feedback/Skeleton.tsx
+++ b/components/feedback/Skeleton.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import { StyleSheet, type DimensionValue, type ViewStyle } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+
+import { radius } from "@/theme";
+
+/**
+ * Skeleton placeholder — subtle opacity pulse on a card-toned block, for
+ * loading states that have a known layout (feedback/ counterpart to
+ * LoadingIndicator, which is for indeterminate full-screen waits). Pulse is
+ * disabled under reduced motion, matching the HomeScreen CTA convention.
+ */
+export function Skeleton({
+  height,
+  width = "100%",
+  borderRadius = radius.card,
+  style,
+}: {
+  height: number;
+  width?: DimensionValue;
+  borderRadius?: number;
+  style?: ViewStyle;
+}) {
+  const reducedMotion = useReducedMotion();
+  const pulse = useSharedValue(0.5);
+
+  useEffect(() => {
+    if (reducedMotion) return;
+    pulse.value = withRepeat(
+      withSequence(withTiming(0.9, { duration: 700 }), withTiming(0.5, { duration: 700 })),
+      -1
+    );
+  }, [pulse, reducedMotion]);
+
+  const pulseStyle = useAnimatedStyle(() => ({ opacity: pulse.value }));
+
+  return (
+    <Animated.View
+      style={[styles.block, { height, width, borderRadius }, pulseStyle, style]}
+      accessibilityElementsHidden
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  block: {
+    backgroundColor: "rgba(255,255,255,0.07)",
+  },
+});

--- a/constants/copy.ts
+++ b/constants/copy.ts
@@ -738,3 +738,90 @@ export const heldagCopy = {
   errorNoContainer: "Ingen lämplig matlåda hittades.",
   errorCalculateMeal: "Kunde inte beräkna måltiden.",
 } as const;
+
+export const rewardsCopy = {
+  /** Mobile-first feature — no web translation keys to mirror yet. */
+  /** Screen + header entry */
+  screenTitle: "Veckans Belöning",
+  headerAvailable: "🎁 Veckans Belöning",
+  headerComeBack: "Kom tillbaka nästa vecka",
+  /** Points summary card */
+  pointsLabel: "Nutri-poäng",
+  pointsUnit: "poäng",
+  activeRewardsLabel: (count: number) =>
+    count === 1 ? "1 aktiv belöning" : `${count} aktiva belöningar`,
+  /** Weekly reward section */
+  weeklySectionHead: "VECKANS BELÖNING",
+  spinCta: "Snurra",
+  spinning: "Snurrar …",
+  spinSubtitle: "En snurr i veckan — belöningen läggs direkt på ditt konto.",
+  comeBackTitle: "Kom tillbaka nästa vecka för en ny spin.",
+  nextSpinLabel: "Nästa spin",
+  daysLeft: (days: number) => (days === 1 ? "1 dag kvar" : `${days} dagar kvar`),
+  countdown: (d: number, h: number, m: number) =>
+    d > 0 ? `${d} d ${h} tim` : h > 0 ? `${h} tim ${m} min` : `${m} min`,
+  wheelUnavailable: "Belöningshjulet är inte tillgängligt just nu. Försök igen senare.",
+  alreadySpun: "Du har redan snurrat denna vecka.",
+  spinError: "Kunde inte snurra hjulet. Kontrollera din anslutning och försök igen.",
+  /** Win modal */
+  modalWinPoints: (amount: string) => `Du vann ${amount} Nutri-poäng`,
+  modalWinCoupon: (pct: string) => `Du vann ${pct} % rabatt`,
+  modalNoWin: "Ingen vinst denna vecka",
+  modalNoWinBody: "Bättre lycka nästa vecka — hjulet väntar på dig igen om 7 dagar.",
+  modalCouponBody: "Kupongen ligger under Mina kuponger och dras av när du beställer.",
+  modalPointsBody: "Poängen är redan tillagda på ditt konto.",
+  modalClose: "Stäng",
+  modalShowRewards: "Visa mina belöningar",
+  /** Launch nudge bottom sheet */
+  nudgeTitle: "🎁 Din veckobelöning väntar!",
+  nudgeBody: "En snurr i veckan — den här veckans har du kvar.",
+  nudgeSpin: "Snurra nu",
+  nudgeLater: "Kanske senare",
+  /** My rewards section */
+  mineSectionHead: "MINA BELÖNINGAR",
+  mineEmpty: "Inga belöningar ännu — snurra hjulet för att vinna din första.",
+  mineFetchError: "Kunde inte hämta dina belöningar.",
+  statusNames: {
+    Unused: "Oanvänd",
+    Redeemed: "Använd",
+    Expired: "Utgången",
+  } as Record<string, string>,
+  validUntil: (date: string) => `Giltig t.o.m. ${date}`,
+  redeemedAt: (date: string) => `Använd ${date}`,
+  expiredAt: (date: string) => `Gick ut ${date}`,
+  wonAt: (date: string) => `Vunnen ${date}`,
+  openCoupon: "Öppna kupong",
+  /** History section */
+  historySectionHead: "HISTORIK",
+  historyEmpty: "Ingen historik ännu.",
+  historyFetchError: "Kunde inte hämta historiken.",
+  historyNoWin: "Ingen vinst",
+  /** Auth gate */
+  loginRequired: "Logga in för att se veckans belöning.",
+  loginCta: "Logga in",
+  retry: "Försök igen",
+  fetchError: "Kunde inte ladda belöningar. Kontrollera din anslutning.",
+} as const;
+
+export const pointsCopy = {
+  /** Mobile-first feature — no web translation keys to mirror yet. */
+  screenTitle: "Nutri-poäng",
+  balanceLabel: "Ditt saldo",
+  balanceUnit: "poäng",
+  historyHead: "TRANSAKTIONER",
+  historyEmpty: "Inga poängtransaktioner ännu — poäng tjänas på ordrar och i Veckans Belöning.",
+  fetchError: "Kunde inte hämta dina poäng.",
+  retry: "Försök igen",
+  loginRequired: "Logga in för att se dina Nutri-poäng.",
+  loginCta: "Logga in",
+  /** Reason → display label. Unknown (future) reasons fall back to the raw
+   * enum name so new earn methods appear without an app update. */
+  reasonNames: {
+    OrderEarned: "Order",
+    WeeklyRewardEarned: "Veckans belöning",
+  } as Record<string, string>,
+  reasonIcons: {
+    OrderEarned: "🛍️",
+    WeeklyRewardEarned: "🎁",
+  } as Record<string, string>,
+} as const;

--- a/features/coupons/WelcomeCouponModal.tsx
+++ b/features/coupons/WelcomeCouponModal.tsx
@@ -34,7 +34,12 @@ import { colors, fontFamily, radius, spacing } from "@/theme";
  * claims.
  */
 
-const PROMPTED_KEY_PREFIX = "nutri-welcome-coupon-prompted:";
+/** Exported so the weekly-reward launch nudge (SpinNudgeSheet) can defer to
+ * this modal: the nudge skips any launch where the welcome prompt hasn't
+ * been answered yet, so two sheets never compete on first login. */
+export const WELCOME_PROMPTED_KEY_PREFIX = "nutri-welcome-coupon-prompted:";
+
+const PROMPTED_KEY_PREFIX = WELCOME_PROMPTED_KEY_PREFIX;
 
 export function WelcomeCouponModal() {
   const router = useRouter();

--- a/features/home/HomeScreen.tsx
+++ b/features/home/HomeScreen.tsx
@@ -6,7 +6,7 @@ import { Image } from "expo-image";
 import { LinearGradient } from "expo-linear-gradient";
 // WandSparkles = the same glyph the web imports as "Wand2" (renamed upstream
 // in newer lucide releases).
-import { ShoppingCart, WandSparkles } from "lucide-react-native";
+import { Gift, ShoppingCart, WandSparkles } from "lucide-react-native";
 import Animated, {
   useAnimatedStyle,
   useReducedMotion,
@@ -18,6 +18,8 @@ import Animated, {
 import { useEffect, useState } from "react";
 
 import { ThemedText } from "@/components/ui/ThemedText";
+import { useAuth } from "@/services/auth/AuthProvider";
+import { getRewardStatus } from "@/services/api/rewards";
 import { getLocation, getStoreStatus } from "@/services/api/store";
 import { deriveLocationStatusKind, getLocationStatusLabel, type LocationStatusKind } from "@/utils/locationStatus";
 import { heroCopy } from "@/constants/copy";
@@ -81,6 +83,16 @@ export function HomeScreen() {
   });
   const locationQuery = useQuery({ queryKey: ["store", "location"], queryFn: getLocation });
 
+  // Weekly reward header entry: green dot = a spin is available. Logged-out
+  // users still see the button (the rewards screen owns the login gate).
+  const { user } = useAuth();
+  const rewardStatusQuery = useQuery({
+    queryKey: ["rewards", "status", user?.id ?? null],
+    queryFn: getRewardStatus,
+    enabled: !!user,
+  });
+  const canSpin = rewardStatusQuery.data?.canSpin === true;
+
   const storeStatus = statusQuery.data ?? null;
   const locationData = locationQuery.data ?? null;
   const storeLoading = statusQuery.isLoading || locationQuery.isLoading;
@@ -117,6 +129,27 @@ export function HomeScreen() {
   }, [breathe, reducedMotion]);
   const breatheStyle = useAnimatedStyle(() => ({ transform: [{ scale: breathe.value }] }));
 
+  // Gift icon gentle float — alive only while a spin is available; stops
+  // (and resets) as soon as the week's reward is claimed. Reduced motion
+  // keeps it static (the green dot alone carries the signal).
+  const giftFloat = useSharedValue(0);
+  useEffect(() => {
+    if (!canSpin || reducedMotion) {
+      giftFloat.value = withTiming(0, { duration: 200 });
+      return;
+    }
+    giftFloat.value = withRepeat(
+      withSequence(
+        withTiming(-2.5, { duration: 1100 }),
+        withTiming(0, { duration: 1100 })
+      ),
+      -1
+    );
+  }, [giftFloat, canSpin, reducedMotion]);
+  const giftFloatStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: giftFloat.value }],
+  }));
+
   const heroImageHeight = Math.min(280, windowHeight * 0.34);
 
   // Viewport height below the fixed header (and above the tab bar) — the
@@ -130,7 +163,17 @@ export function HomeScreen() {
     <View style={styles.root}>
       {/* ── Fixed header: logo centered, cart right (hamburger omitted — tabs) ── */}
       <View style={[styles.header, { paddingTop: insets.top }]}>
-        <View style={styles.headerSide} />
+        <Pressable
+          style={styles.cartButton}
+          onPress={() => router.push("/beloningar")}
+          accessibilityRole="button"
+          accessibilityLabel={canSpin ? "Veckans belöning — en spin väntar" : "Veckans belöning"}
+        >
+          <Animated.View style={giftFloatStyle}>
+            <Gift size={20} color={canSpin ? colors.accent : colors.textPrimary} />
+          </Animated.View>
+          {canSpin ? <View style={styles.rewardDot} /> : null}
+        </Pressable>
         <Image
           source={require("@/assets/nutri-logo.png")}
           style={styles.logo}
@@ -285,8 +328,16 @@ const styles = StyleSheet.create({
     paddingBottom: spacing[2],
     backgroundColor: "rgba(11,11,11,0.72)",
   },
-  headerSide: {
-    width: 36,
+  rewardDot: {
+    position: "absolute",
+    top: 7,
+    right: 7,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: "#4ade80",
+    borderWidth: 1.5,
+    borderColor: "#0B0B0B",
   },
   logo: {
     width: 42,

--- a/features/points/PointsScreen.tsx
+++ b/features/points/PointsScreen.tsx
@@ -1,0 +1,271 @@
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { useRouter } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeft, Star } from "lucide-react-native";
+
+import { Screen } from "@/components/ui/Screen";
+import { ThemedText } from "@/components/ui/ThemedText";
+import { Skeleton } from "@/components/feedback/Skeleton";
+import { EmptyState } from "@/components/feedback/EmptyState";
+import { useAuth } from "@/services/auth/AuthProvider";
+import { getMyPointsTransactions, type ApiPointsTransaction } from "@/services/api/points";
+import { getRewardStatus } from "@/services/api/rewards";
+import { pointsCopy as copy } from "@/constants/copy";
+import { colors, fontFamily, radius, spacing } from "@/theme";
+
+/**
+ * Nutri-poäng — balance + ledger. Balance comes from GET /api/rewards/status
+ * (already the single source for header/rewards data — no duplicate
+ * endpoint); the ledger from GET /api/points/transactions. Reason labels
+ * fall back to the raw enum name, so future earn reasons (referrals,
+ * challenges, campaigns) render without an app update. Spending is
+ * deliberately absent — display only in V1.
+ */
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("sv-SE", { day: "numeric", month: "long" });
+}
+
+function TransactionRow({ tx }: { tx: ApiPointsTransaction }) {
+  const label = copy.reasonNames[tx.reason] ?? tx.reason;
+  const icon = copy.reasonIcons[tx.reason] ?? "⭐";
+  return (
+    <View style={styles.txRow}>
+      <View style={styles.txIconWrap}>
+        <ThemedText style={styles.txIcon}>{icon}</ThemedText>
+      </View>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <ThemedText style={styles.txLabel}>{label}</ThemedText>
+        <ThemedText style={styles.txDate}>{formatDate(tx.createdAt)}</ThemedText>
+      </View>
+      <ThemedText style={[styles.txAmount, tx.amount < 0 && styles.txAmountNegative]}>
+        {tx.amount > 0 ? `+${tx.amount}` : `${tx.amount}`}
+      </ThemedText>
+    </View>
+  );
+}
+
+export function PointsScreen() {
+  const router = useRouter();
+  const { user, loading: authLoading } = useAuth();
+
+  const statusQuery = useQuery({
+    queryKey: ["rewards", "status", user?.id ?? null],
+    queryFn: getRewardStatus,
+    enabled: !!user,
+  });
+  const txQuery = useQuery({
+    queryKey: ["points", "transactions", user?.id ?? null],
+    queryFn: getMyPointsTransactions,
+    enabled: !!user,
+  });
+
+  return (
+    <Screen edges={["top", "bottom"]}>
+      {/* Back header — same pattern as CouponListScreen/RewardsScreen */}
+      <View style={styles.header}>
+        <Pressable
+          onPress={() => (router.canGoBack() ? router.back() : router.navigate("/(tabs)"))}
+          style={styles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel="Tillbaka"
+          hitSlop={8}
+        >
+          <ArrowLeft size={16} color={colors.textPrimary} strokeWidth={2.25} />
+        </Pressable>
+        <ThemedText style={styles.headerTitle}>{copy.screenTitle}</ThemedText>
+        <View style={styles.backButton} />
+      </View>
+
+      {authLoading ? (
+        <View style={styles.skeletons}>
+          <Skeleton height={96} />
+          <Skeleton height={64} />
+          <Skeleton height={64} />
+        </View>
+      ) : !user ? (
+        <View style={styles.center}>
+          <ThemedText style={styles.loginText}>{copy.loginRequired}</ThemedText>
+          <Pressable
+            onPress={() => router.push({ pathname: "/logga-in", params: { next: "/poang" } })}
+            style={({ pressed }) => [
+              styles.loginButton,
+              pressed && { backgroundColor: colors.accentHover },
+            ]}
+            accessibilityRole="button"
+          >
+            <ThemedText style={styles.loginButtonText}>{copy.loginCta}</ThemedText>
+          </Pressable>
+        </View>
+      ) : (
+        <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+          {/* ── Balance card ── */}
+          {statusQuery.isLoading ? (
+            <Skeleton height={96} />
+          ) : (
+            <View style={styles.balanceCard}>
+              <View style={styles.balanceIconWrap}>
+                <Star size={22} color={colors.accent} strokeWidth={1.75} />
+              </View>
+              <View>
+                <ThemedText style={styles.balanceLabel}>{copy.balanceLabel}</ThemedText>
+                <ThemedText style={styles.balanceValue}>
+                  {statusQuery.data?.pointsBalance ?? "–"}{" "}
+                  <ThemedText style={styles.balanceUnit}>{copy.balanceUnit}</ThemedText>
+                </ThemedText>
+              </View>
+            </View>
+          )}
+
+          {/* ── Ledger ── */}
+          <ThemedText style={styles.sectionHead}>{copy.historyHead}</ThemedText>
+          {txQuery.isLoading ? (
+            <View style={{ gap: spacing[3] }}>
+              <Skeleton height={64} />
+              <Skeleton height={64} />
+              <Skeleton height={64} />
+            </View>
+          ) : txQuery.isError ? (
+            <View style={styles.inlineError}>
+              <ThemedText style={styles.errorText}>{copy.fetchError}</ThemedText>
+              <Pressable
+                onPress={() => txQuery.refetch()}
+                style={styles.retryButton}
+                accessibilityRole="button"
+              >
+                <ThemedText style={styles.retryText}>{copy.retry}</ThemedText>
+              </Pressable>
+            </View>
+          ) : txQuery.data && txQuery.data.length > 0 ? (
+            <View style={styles.txCard}>
+              {txQuery.data.map((tx, i) => (
+                <View key={tx.id}>
+                  {i > 0 ? <View style={styles.txDivider} /> : null}
+                  <TransactionRow tx={tx} />
+                </View>
+              ))}
+            </View>
+          ) : (
+            <EmptyState message={copy.historyEmpty} />
+          )}
+        </ScrollView>
+      )}
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    height: 48,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255,255,255,0.06)",
+  },
+  backButton: { width: 36, height: 36, alignItems: "center", justifyContent: "center" },
+  headerTitle: {
+    fontSize: 15,
+    fontFamily: fontFamily.bodyBold,
+    letterSpacing: -0.2,
+    color: colors.textPrimary,
+  },
+  content: { padding: spacing[4], paddingBottom: spacing[8], gap: spacing[4] },
+  skeletons: { padding: spacing[4], gap: spacing[4] },
+  center: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing[4],
+    padding: spacing[6],
+  },
+
+  balanceCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing[4],
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.22)",
+    borderRadius: radius.card,
+    padding: spacing[5],
+  },
+  balanceIconWrap: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(232,101,10,0.10)",
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.22)",
+  },
+  balanceLabel: { fontSize: 11.5, color: colors.textTertiary },
+  balanceValue: {
+    fontSize: 26,
+    fontFamily: fontFamily.bodyBold,
+    letterSpacing: -0.5,
+    color: colors.textPrimary,
+  },
+  balanceUnit: { fontSize: 13, fontFamily: fontFamily.bodyMedium, color: colors.textTertiary },
+
+  sectionHead: {
+    fontSize: 11,
+    fontFamily: fontFamily.bodySemibold,
+    letterSpacing: 1.5,
+    color: colors.textMuted,
+    marginTop: spacing[2],
+  },
+  txCard: {
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.card,
+    paddingHorizontal: spacing[4],
+  },
+  txRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing[3],
+    paddingVertical: spacing[3],
+  },
+  txDivider: { height: 1, backgroundColor: "rgba(255,255,255,0.06)" },
+  txIconWrap: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(232,101,10,0.10)",
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.22)",
+  },
+  txIcon: { fontSize: 15, lineHeight: 20 },
+  txLabel: { fontSize: 13.5, fontFamily: fontFamily.bodySemibold, color: colors.textPrimary },
+  txDate: { marginTop: 1, fontSize: 11.5, color: colors.textTertiary },
+  txAmount: { fontSize: 14, fontFamily: fontFamily.bodyBold, color: "#4ade80" },
+  txAmountNegative: { color: "#f87171" },
+
+  loginText: { fontSize: 13.5, color: colors.textSecondary, textAlign: "center" },
+  loginButton: {
+    height: 44,
+    borderRadius: radius.card,
+    backgroundColor: colors.accent,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: spacing[6],
+  },
+  loginButtonText: { fontSize: 13.5, fontFamily: fontFamily.bodyBold, color: colors.textPrimary },
+  inlineError: { alignItems: "center", gap: spacing[3], paddingVertical: spacing[4] },
+  errorText: { fontSize: 12.5, color: "#f87171", textAlign: "center" },
+  retryButton: {
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.35)",
+    backgroundColor: "rgba(232,101,10,0.12)",
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+  },
+  retryText: { fontSize: 12.5, fontFamily: fontFamily.bodySemibold, color: colors.accent },
+});

--- a/features/profile/ProfileScreen.tsx
+++ b/features/profile/ProfileScreen.tsx
@@ -25,7 +25,7 @@ import {
   type WeeklyScheduleDto,
 } from "@/services/api/weeklySchedule";
 import { ACTIVE_ORDER_KEY } from "@/utils/activeOrder";
-import { authCopy, couponCopy, profileCopy as copy } from "@/constants/copy";
+import { authCopy, couponCopy, pointsCopy, profileCopy as copy } from "@/constants/copy";
 import { colors, fontFamily, spacing } from "@/theme";
 import {
   deriveTrainingSessionsFromWeeklySchedule,
@@ -570,6 +570,14 @@ export function ProfileScreen() {
           accessibilityRole="button"
         >
           <ThemedText style={styles.navRowText}>{couponCopy.listTitle}</ThemedText>
+          <ChevronRight size={14} color="rgba(255,255,255,0.32)" />
+        </Pressable>
+        <Pressable
+          onPress={() => router.push("/poang")}
+          style={styles.navRow}
+          accessibilityRole="button"
+        >
+          <ThemedText style={styles.navRowText}>{pointsCopy.screenTitle}</ThemedText>
           <ChevronRight size={14} color="rgba(255,255,255,0.32)" />
         </Pressable>
         <Pressable

--- a/features/rewards/RewardWheel.tsx
+++ b/features/rewards/RewardWheel.tsx
@@ -37,6 +37,17 @@ const RADIUS = CENTER - 8;
 
 const SLICE_FILLS = ["rgba(255,255,255,0.05)", "rgba(232,101,10,0.10)"];
 
+/** Decorative equal-width stand-ins while segments load (or if the wheel
+ * endpoint fails) — the wheel should never render as a blank disc. No
+ * labels: placeholders must not imply prizes that may not exist. */
+const FALLBACK_SEGMENTS: ApiWheelSegment[] = Array.from({ length: 8 }, (_, i) => ({
+  id: `fallback-${i}`,
+  title: "",
+  icon: "",
+  probabilityWeight: 1,
+  displayOrder: i,
+}));
+
 interface Slice {
   segment: ApiWheelSegment;
   /** Degrees from 12 o'clock, clockwise. */
@@ -92,7 +103,10 @@ export function RewardWheel({
   const rotation = useSharedValue(0);
   const everSpun = useRef(false);
 
-  const slices = useMemo(() => buildSlices(segments), [segments]);
+  const slices = useMemo(
+    () => buildSlices(segments.length > 0 ? segments : FALLBACK_SEGMENTS),
+    [segments]
+  );
 
   useEffect(() => {
     if (spinning) {
@@ -178,9 +192,21 @@ export function RewardWheel({
             ))}
 
             {/* Icon + label along each slice bisector */}
-            {slices.map((slice) => {
+            {slices.map((slice, i) => {
               const mid = slice.startDeg + slice.sweepDeg / 2;
               const iconPos = polar(mid, RADIUS * 0.56);
+              if (!slice.segment.icon && !slice.segment.title) {
+                // Fallback slice — a muted dot instead of icon/label.
+                return (
+                  <Circle
+                    key={`label-${slice.segment.id}`}
+                    cx={iconPos.x}
+                    cy={iconPos.y}
+                    r={3}
+                    fill={i % 2 === 0 ? "rgba(255,255,255,0.22)" : "rgba(232,101,10,0.55)"}
+                  />
+                );
+              }
               const labelPos = polar(mid, RADIUS * 0.8);
               // Keep labels upright-ish: flip text on the lower half.
               const flip = mid > 90 && mid < 270;

--- a/features/rewards/RewardWheel.tsx
+++ b/features/rewards/RewardWheel.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useMemo, useRef } from "react";
+import { StyleSheet, View } from "react-native";
+import Svg, { Circle, G, Path, Text as SvgText } from "react-native-svg";
+import * as Haptics from "expo-haptics";
+import { Gift } from "lucide-react-native";
+import Animated, {
+  cancelAnimation,
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+
+import { colors, fontFamily } from "@/theme";
+import type { ApiWheelSegment } from "@/services/api/rewards";
+
+/**
+ * The reward wheel — visual only, but truthful: slices are rendered from
+ * GET /api/rewards/wheel with arc width PROPORTIONAL to each segment's
+ * ProbabilityWeight, and the wheel lands on the slice the backend actually
+ * drew (targetSegmentId from the spin response). The outcome is decided
+ * server-side before the wheel ever decelerates.
+ *
+ * Animation: natural spin-up (ease-in) → cruise while the request is in
+ * flight → long ease-out deceleration (~4.5 s) onto the drawn slice, with a
+ * subtle success/light haptic at rest. No sounds (the project has no audio
+ * dependency — deliberately skipped). Reduced motion settles instantly.
+ */
+
+const SIZE = 264;
+const CENTER = SIZE / 2;
+const RADIUS = CENTER - 8;
+
+const SLICE_FILLS = ["rgba(255,255,255,0.05)", "rgba(232,101,10,0.10)"];
+
+interface Slice {
+  segment: ApiWheelSegment;
+  /** Degrees from 12 o'clock, clockwise. */
+  startDeg: number;
+  sweepDeg: number;
+}
+
+/** Cumulative, weight-proportional slice layout starting at 12 o'clock. */
+function buildSlices(segments: ApiWheelSegment[]): Slice[] {
+  const total = segments.reduce((sum, s) => sum + Math.max(1, s.probabilityWeight), 0);
+  let cursor = 0;
+  return segments.map((segment) => {
+    const sweepDeg = (Math.max(1, segment.probabilityWeight) / total) * 360;
+    const slice = { segment, startDeg: cursor, sweepDeg };
+    cursor += sweepDeg;
+    return slice;
+  });
+}
+
+function polar(deg: number, r: number): { x: number; y: number } {
+  const rad = ((deg - 90) * Math.PI) / 180; // -90: 0° is 12 o'clock
+  return { x: CENTER + r * Math.cos(rad), y: CENTER + r * Math.sin(rad) };
+}
+
+function arcPath(startDeg: number, sweepDeg: number): string {
+  const p1 = polar(startDeg, RADIUS);
+  const p2 = polar(startDeg + sweepDeg, RADIUS);
+  const largeArc = sweepDeg > 180 ? 1 : 0;
+  return `M ${CENTER} ${CENTER} L ${p1.x} ${p1.y} A ${RADIUS} ${RADIUS} 0 ${largeArc} 1 ${p2.x} ${p2.y} Z`;
+}
+
+/** Truncate long titles so radial labels stay inside the slice. */
+function sliceLabel(title: string): string {
+  return title.length > 14 ? `${title.slice(0, 13)}…` : title;
+}
+
+export function RewardWheel({
+  segments,
+  spinning,
+  targetSegmentId,
+  onSettled,
+}: {
+  /** Real wheel segments (GET /api/rewards/wheel); empty while loading. */
+  segments: ApiWheelSegment[];
+  /** True from Spin press until the API response landed. */
+  spinning: boolean;
+  /** The backend-drawn segment to land on (null → random landing). */
+  targetSegmentId: string | null;
+  /** Fired once the deceleration animation has come to rest. */
+  onSettled?: () => void;
+}) {
+  const reducedMotion = useReducedMotion();
+  const rotation = useSharedValue(0);
+  const everSpun = useRef(false);
+
+  const slices = useMemo(() => buildSlices(segments), [segments]);
+
+  useEffect(() => {
+    if (spinning) {
+      everSpun.current = true;
+      if (reducedMotion) return; // Settle instantly on stop instead.
+      // Natural spin-up, then steady cruise while the backend decides.
+      rotation.value = withSequence(
+        withTiming(rotation.value + 240, { duration: 700, easing: Easing.in(Easing.quad) }),
+        withRepeat(
+          withTiming(rotation.value + 240 + 360, { duration: 480, easing: Easing.linear }),
+          -1
+        )
+      );
+      return;
+    }
+
+    if (!everSpun.current) return; // Initial mount — nothing to settle.
+
+    cancelAnimation(rotation);
+
+    // Land the drawn slice's bisector under the 12-o'clock pointer, with a
+    // little in-slice jitter so repeated wins don't look mechanical.
+    const target = slices.find((s) => s.segment.id === targetSegmentId);
+    let landingDeg = Math.random() * 360;
+    if (target) {
+      const jitter = (Math.random() - 0.5) * target.sweepDeg * 0.5;
+      const bisector = target.startDeg + target.sweepDeg / 2 + jitter;
+      // Rotating the wheel by R puts local angle A at screen angle A + R;
+      // the pointer reads local angle -R (mod 360) — so R = 360 - bisector.
+      landingDeg = (360 - bisector) % 360;
+    }
+
+    const settle = onSettled;
+    const settleWithHaptic = () => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+      settle?.();
+    };
+
+    if (reducedMotion) {
+      rotation.value = landingDeg;
+      settleWithHaptic();
+      return;
+    }
+
+    // Long, satisfying deceleration: at least 4 extra full turns.
+    const current = rotation.value;
+    const finalRotation = Math.ceil(current / 360) * 360 + 4 * 360 + landingDeg;
+    rotation.value = withTiming(
+      finalRotation,
+      { duration: 4500, easing: Easing.out(Easing.poly(4)) },
+      (finished) => {
+        if (finished) runOnJS(settleWithHaptic)();
+      }
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rotation is a stable shared value; slices/target are read at stop-time only
+  }, [spinning, reducedMotion]);
+
+  const wheelStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
+
+  return (
+    <View style={styles.wrap} accessibilityLabel="Belöningshjul" accessibilityRole="image">
+      {/* Pointer */}
+      <View style={styles.pointer} />
+
+      <Animated.View style={wheelStyle}>
+        <Svg width={SIZE} height={SIZE}>
+          <G>
+            {slices.map((slice, i) => (
+              <Path
+                key={slice.segment.id}
+                d={
+                  slices.length === 1
+                    ? // A single segment is the whole disc — arcs degenerate.
+                      `M ${CENTER} ${CENTER} m 0 ${-RADIUS} a ${RADIUS} ${RADIUS} 0 1 1 0 ${2 * RADIUS} a ${RADIUS} ${RADIUS} 0 1 1 0 ${-2 * RADIUS}`
+                    : arcPath(slice.startDeg, slice.sweepDeg)
+                }
+                fill={SLICE_FILLS[i % SLICE_FILLS.length]}
+                stroke="rgba(255,255,255,0.09)"
+                strokeWidth={1}
+              />
+            ))}
+
+            {/* Icon + label along each slice bisector */}
+            {slices.map((slice) => {
+              const mid = slice.startDeg + slice.sweepDeg / 2;
+              const iconPos = polar(mid, RADIUS * 0.56);
+              const labelPos = polar(mid, RADIUS * 0.8);
+              // Keep labels upright-ish: flip text on the lower half.
+              const flip = mid > 90 && mid < 270;
+              const labelRotation = flip ? mid + 180 : mid;
+              return (
+                <G key={`label-${slice.segment.id}`}>
+                  <SvgText
+                    x={iconPos.x}
+                    y={iconPos.y}
+                    fontSize={slice.sweepDeg < 45 ? 14 : 18}
+                    textAnchor="middle"
+                    alignmentBaseline="central"
+                  >
+                    {slice.segment.icon}
+                  </SvgText>
+                  {slice.sweepDeg >= 28 ? (
+                    <SvgText
+                      x={labelPos.x}
+                      y={labelPos.y}
+                      fontSize={8.5}
+                      fontFamily={fontFamily.bodySemibold}
+                      fill="rgba(255,255,255,0.65)"
+                      textAnchor="middle"
+                      alignmentBaseline="central"
+                      transform={`rotate(${labelRotation} ${labelPos.x} ${labelPos.y})`}
+                    >
+                      {sliceLabel(slice.segment.title)}
+                    </SvgText>
+                  ) : null}
+                </G>
+              );
+            })}
+
+            {/* Outer ring */}
+            <Circle
+              cx={CENTER}
+              cy={CENTER}
+              r={RADIUS}
+              fill="none"
+              stroke="rgba(255,255,255,0.16)"
+              strokeWidth={1.5}
+            />
+          </G>
+        </Svg>
+      </Animated.View>
+
+      {/* Static center hub */}
+      <View style={styles.hub}>
+        <Gift size={22} color={colors.accent} strokeWidth={1.75} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    width: SIZE,
+    height: SIZE,
+    alignItems: "center",
+    justifyContent: "center",
+    alignSelf: "center",
+  },
+  pointer: {
+    position: "absolute",
+    top: -3,
+    zIndex: 2,
+    width: 0,
+    height: 0,
+    borderLeftWidth: 8,
+    borderRightWidth: 8,
+    borderTopWidth: 14,
+    borderLeftColor: "transparent",
+    borderRightColor: "transparent",
+    borderTopColor: colors.accent,
+  },
+  hub: {
+    position: "absolute",
+    width: 58,
+    height: 58,
+    borderRadius: 29,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.28)",
+  },
+});

--- a/features/rewards/RewardsScreen.tsx
+++ b/features/rewards/RewardsScreen.tsx
@@ -1,0 +1,646 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { useRouter } from "expo-router";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, CalendarClock, ChevronRight, Star } from "lucide-react-native";
+import Animated, { FadeInDown, useReducedMotion } from "react-native-reanimated";
+
+import { Screen } from "@/components/ui/Screen";
+import { ThemedText } from "@/components/ui/ThemedText";
+import { Skeleton } from "@/components/feedback/Skeleton";
+import { EmptyState } from "@/components/feedback/EmptyState";
+import { useAuth } from "@/services/auth/AuthProvider";
+import {
+  getMyRewards,
+  getRewardHistory,
+  getRewardStatus,
+  getWheelSegments,
+  spinRewardWheel,
+  type ApiRewardHistoryEntry,
+  type ApiSpinResult,
+  type ApiUserReward,
+} from "@/services/api/rewards";
+import type { ApiError } from "@/types/api";
+import { rewardsCopy as copy } from "@/constants/copy";
+import { colors, fontFamily, radius, spacing } from "@/theme";
+import { RewardWheel } from "./RewardWheel";
+import { SpinResultModal } from "./SpinResultModal";
+import {
+  countdownParts,
+  formatRewardDate,
+  REWARD_STATUS_COLORS,
+  rewardMetaLine,
+} from "./rewardFormat";
+
+/**
+ * Veckans Belöning — the weekly reward wheel screen. Composition:
+ *   1. Points summary (balance + active-rewards count, one /status call)
+ *   2. Weekly reward: the wheel + spin CTA when canSpin, otherwise the
+ *      come-back card with a live countdown to nextSpinAt
+ *   3. Mina belöningar (GET /mine) — coupon rewards open the EXISTING
+ *      /kupong/[id] detail screen (no duplicated coupon UI)
+ *   4. Historik (GET /history) — timeline, newest first (server-sorted)
+ *
+ * Spin flow: pressing Snurra fires POST /spin immediately — the backend
+ * decides the outcome while the wheel animates. When the response lands the
+ * wheel decelerates; only after it settles does the result modal appear.
+ * The client NEVER determines the reward.
+ */
+
+function StatusBadge({ status }: { status: string }) {
+  const cfg = REWARD_STATUS_COLORS[status] ?? REWARD_STATUS_COLORS.Redeemed;
+  const label = copy.statusNames[status] ?? status;
+  return (
+    <View style={[styles.statusBadge, { backgroundColor: cfg.bg }]}>
+      <ThemedText style={[styles.statusBadgeText, { color: cfg.color }]}>{label}</ThemedText>
+    </View>
+  );
+}
+
+function SectionHead({ label }: { label: string }) {
+  return <ThemedText style={styles.sectionHead}>{label}</ThemedText>;
+}
+
+// ── Section 0: points summary ────────────────────────────────────────────
+
+function PointsCard({ balance, activeRewards }: { balance: number; activeRewards: number }) {
+  return (
+    <View style={styles.pointsCard}>
+      <View style={styles.pointsIconWrap}>
+        <Star size={20} color={colors.accent} strokeWidth={1.75} />
+      </View>
+      <View style={{ flex: 1 }}>
+        <ThemedText style={styles.pointsLabel}>{copy.pointsLabel}</ThemedText>
+        <ThemedText style={styles.pointsValue}>{balance}</ThemedText>
+      </View>
+      <ThemedText style={styles.pointsActive}>{copy.activeRewardsLabel(activeRewards)}</ThemedText>
+    </View>
+  );
+}
+
+// ── Section 1: the wheel / come-back card ────────────────────────────────
+
+function CountdownCard({ nextSpinAt }: { nextSpinAt: string }) {
+  // Minute-resolution tick keeps the countdown live without burning renders.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const { d, h, m } = countdownParts(nextSpinAt);
+  const label = d >= 1 ? copy.daysLeft(h > 0 || m > 0 ? d + 1 : d) : copy.countdown(0, h, m);
+
+  return (
+    <View style={styles.comeBackCard}>
+      <View style={styles.comeBackIconWrap}>
+        <CalendarClock size={22} color={colors.accent} strokeWidth={1.75} />
+      </View>
+      <ThemedText style={styles.comeBackTitle}>{copy.comeBackTitle}</ThemedText>
+      <View style={styles.countdownChip}>
+        <ThemedText style={styles.countdownText}>
+          {copy.nextSpinLabel} · {label}
+        </ThemedText>
+      </View>
+    </View>
+  );
+}
+
+// ── Section 2: my rewards ────────────────────────────────────────────────
+
+function RewardCard({ reward }: { reward: ApiUserReward }) {
+  const router = useRouter();
+  const isOpenableCoupon = reward.rewardType === "Coupon" && !!reward.couponId;
+  const inactive = reward.status !== "Unused";
+
+  const card = (
+    <View style={[styles.rewardCard, inactive && { opacity: 0.55 }]}>
+      <View style={styles.rewardIconWrap}>
+        <ThemedText style={styles.rewardIcon}>{reward.icon || "🎁"}</ThemedText>
+      </View>
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <View style={styles.rewardTitleRow}>
+          <ThemedText style={styles.rewardTitle} numberOfLines={1}>
+            {reward.title}
+          </ThemedText>
+          <StatusBadge status={reward.status} />
+        </View>
+        <ThemedText style={styles.rewardMeta}>{rewardMetaLine(reward)}</ThemedText>
+        {isOpenableCoupon ? (
+          <ThemedText style={styles.rewardOpenHint}>{copy.openCoupon}</ThemedText>
+        ) : null}
+      </View>
+      {isOpenableCoupon ? <ChevronRight size={15} color="rgba(255,255,255,0.3)" /> : null}
+    </View>
+  );
+
+  if (!isOpenableCoupon) return card;
+  return (
+    <Pressable
+      onPress={() => router.push(`/kupong/${reward.couponId}`)}
+      style={({ pressed }) => pressed && { opacity: 0.8 }}
+      accessibilityRole="button"
+      accessibilityLabel={`${reward.title}, ${copy.openCoupon}`}
+    >
+      {card}
+    </Pressable>
+  );
+}
+
+// ── Section 3: history timeline ──────────────────────────────────────────
+
+function HistoryRow({ entry, isLast }: { entry: ApiRewardHistoryEntry; isLast: boolean }) {
+  const noWin = entry.resultType === "NoReward";
+  return (
+    <View style={styles.historyRow}>
+      <View style={styles.historyRail}>
+        <View style={[styles.historyDot, noWin && styles.historyDotMuted]} />
+        {!isLast ? <View style={styles.historyLine} /> : null}
+      </View>
+      <View style={styles.historyBody}>
+        <ThemedText style={styles.historyDate}>{formatRewardDate(entry.spunAt)}</ThemedText>
+        <View style={styles.historyTitleRow}>
+          <ThemedText style={styles.historyIcon}>{entry.icon || (noWin ? "😔" : "🎁")}</ThemedText>
+          <ThemedText style={[styles.historyTitle, noWin && { color: colors.textTertiary }]}>
+            {noWin ? copy.historyNoWin : entry.title}
+          </ThemedText>
+          {entry.rewardStatus ? <StatusBadge status={entry.rewardStatus} /> : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// ── Screen ───────────────────────────────────────────────────────────────
+
+export function RewardsScreen() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const reducedMotion = useReducedMotion();
+  const { user, loading: authLoading } = useAuth();
+
+  const statusQuery = useQuery({
+    queryKey: ["rewards", "status", user?.id ?? null],
+    queryFn: getRewardStatus,
+    enabled: !!user,
+  });
+  const mineQuery = useQuery({
+    queryKey: ["rewards", "mine", user?.id ?? null],
+    queryFn: getMyRewards,
+    enabled: !!user,
+  });
+  const historyQuery = useQuery({
+    queryKey: ["rewards", "history", user?.id ?? null],
+    queryFn: getRewardHistory,
+    enabled: !!user,
+  });
+  const wheelQuery = useQuery({
+    queryKey: ["rewards", "wheel", user?.id ?? null],
+    queryFn: getWheelSegments,
+    enabled: !!user,
+  });
+
+  // Spin state machine: idle → spinning (request in flight, wheel turning)
+  // → settling (response landed, wheel decelerating) → modal.
+  const [wheelSpinning, setWheelSpinning] = useState(false);
+  const [spinBusy, setSpinBusy] = useState(false);
+  const [spinErrorText, setSpinErrorText] = useState<string | null>(null);
+  const [targetSegmentId, setTargetSegmentId] = useState<string | null>(null);
+  const pendingResult = useRef<ApiSpinResult | null>(null);
+  const [modalResult, setModalResult] = useState<ApiSpinResult | null>(null);
+
+  const scrollRef = useRef<ScrollView>(null);
+  const mineSectionY = useRef(0);
+
+  const invalidateRewardData = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["rewards"] });
+    // A coupon win minted a real Coupon row — the coupon list/cart must see it.
+    queryClient.invalidateQueries({ queryKey: ["coupons"] });
+  }, [queryClient]);
+
+  const handleSpin = async () => {
+    if (spinBusy) return;
+    setSpinBusy(true);
+    setSpinErrorText(null);
+    setWheelSpinning(true);
+    try {
+      const result = await spinRewardWheel();
+      pendingResult.current = result;
+      setTargetSegmentId(result.weeklyRewardId);
+    } catch (err) {
+      const apiErr = err as ApiError;
+      pendingResult.current = null;
+      if (apiErr.status === 409) {
+        setSpinErrorText(copy.alreadySpun);
+        statusQuery.refetch();
+      } else if (apiErr.status === 503) {
+        setSpinErrorText(copy.wheelUnavailable);
+      } else if (apiErr.status === 0) {
+        setSpinErrorText(apiErr.message); // Offline copy from the client.
+      } else {
+        setSpinErrorText(copy.spinError);
+      }
+    } finally {
+      // Either way the wheel decelerates; the modal only opens when a
+      // result is pending (see handleWheelSettled).
+      setWheelSpinning(false);
+    }
+  };
+
+  const handleWheelSettled = useCallback(() => {
+    setSpinBusy(false);
+    if (pendingResult.current) {
+      setModalResult(pendingResult.current);
+      pendingResult.current = null;
+      invalidateRewardData();
+    }
+  }, [invalidateRewardData]);
+
+  const closeModal = () => setModalResult(null);
+  const showMyRewards = () => {
+    setModalResult(null);
+    scrollRef.current?.scrollTo({ y: mineSectionY.current - spacing[4], animated: true });
+  };
+
+  const status = statusQuery.data;
+  const entering = (index: number) =>
+    reducedMotion ? undefined : FadeInDown.delay(index * 50).duration(280);
+
+  return (
+    <Screen edges={["top", "bottom"]}>
+      {/* Back header — same pattern as CouponListScreen/OrderStatusScreen */}
+      <View style={styles.header}>
+        <Pressable
+          onPress={() => (router.canGoBack() ? router.back() : router.navigate("/(tabs)"))}
+          style={styles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel="Tillbaka"
+          hitSlop={8}
+        >
+          <ArrowLeft size={16} color={colors.textPrimary} strokeWidth={2.25} />
+        </Pressable>
+        <ThemedText style={styles.headerTitle}>{copy.screenTitle}</ThemedText>
+        <View style={styles.backButton} />
+      </View>
+
+      {authLoading ? (
+        <View style={styles.skeletons}>
+          <Skeleton height={76} />
+          <Skeleton height={280} />
+          <Skeleton height={72} />
+        </View>
+      ) : !user ? (
+        <View style={styles.center}>
+          <ThemedText style={styles.loginText}>{copy.loginRequired}</ThemedText>
+          <Pressable
+            onPress={() => router.push({ pathname: "/logga-in", params: { next: "/beloningar" } })}
+            style={({ pressed }) => [
+              styles.primaryButton,
+              { alignSelf: "center", paddingHorizontal: spacing[6] },
+              pressed && { backgroundColor: colors.accentHover },
+            ]}
+            accessibilityRole="button"
+          >
+            <ThemedText style={styles.primaryButtonText}>{copy.loginCta}</ThemedText>
+          </Pressable>
+        </View>
+      ) : statusQuery.isLoading ? (
+        <View style={styles.skeletons}>
+          <Skeleton height={76} />
+          <Skeleton height={280} />
+          <Skeleton height={72} />
+          <Skeleton height={72} />
+        </View>
+      ) : statusQuery.isError ? (
+        <View style={styles.center}>
+          <ThemedText style={styles.errorText}>{copy.fetchError}</ThemedText>
+          <Pressable
+            onPress={() => statusQuery.refetch()}
+            style={styles.retryButton}
+            accessibilityRole="button"
+          >
+            <ThemedText style={styles.retryText}>{copy.retry}</ThemedText>
+          </Pressable>
+        </View>
+      ) : status ? (
+        <ScrollView
+          ref={scrollRef}
+          contentContainerStyle={styles.content}
+          showsVerticalScrollIndicator={false}
+        >
+          {/* ── Points summary ── */}
+          <Animated.View entering={entering(0)}>
+            <PointsCard balance={status.pointsBalance} activeRewards={status.activeRewards} />
+          </Animated.View>
+
+          {/* ── Weekly reward ── */}
+          <Animated.View entering={entering(1)}>
+            <SectionHead label={copy.weeklySectionHead} />
+            {status.canSpin || spinBusy ? (
+              <View style={styles.wheelCard}>
+                <RewardWheel
+                  segments={wheelQuery.data ?? []}
+                  spinning={wheelSpinning}
+                  targetSegmentId={targetSegmentId}
+                  onSettled={handleWheelSettled}
+                />
+                <ThemedText style={styles.wheelSubtitle}>{copy.spinSubtitle}</ThemedText>
+                {spinErrorText ? (
+                  <ThemedText style={styles.errorText}>{spinErrorText}</ThemedText>
+                ) : null}
+                <Pressable
+                  onPress={handleSpin}
+                  disabled={spinBusy}
+                  style={({ pressed }) => [
+                    styles.primaryButton,
+                    styles.spinButton,
+                    pressed && !spinBusy && { backgroundColor: colors.accentHover },
+                    spinBusy && { opacity: 0.6 },
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityState={{ disabled: spinBusy }}
+                >
+                  <ThemedText style={styles.primaryButtonText}>
+                    {spinBusy ? copy.spinning : copy.spinCta}
+                  </ThemedText>
+                </Pressable>
+              </View>
+            ) : status.nextSpinAt ? (
+              <CountdownCard nextSpinAt={status.nextSpinAt} />
+            ) : (
+              <View style={styles.comeBackCard}>
+                <ThemedText style={styles.comeBackTitle}>{copy.wheelUnavailable}</ThemedText>
+              </View>
+            )}
+          </Animated.View>
+
+          {/* ── My rewards ── */}
+          <Animated.View
+            entering={entering(2)}
+            onLayout={(e) => {
+              mineSectionY.current = e.nativeEvent.layout.y;
+            }}
+          >
+            <SectionHead label={copy.mineSectionHead} />
+            {mineQuery.isLoading ? (
+              <View style={{ gap: spacing[3] }}>
+                <Skeleton height={72} />
+                <Skeleton height={72} />
+              </View>
+            ) : mineQuery.isError ? (
+              <InlineError text={copy.mineFetchError} onRetry={() => mineQuery.refetch()} />
+            ) : mineQuery.data && mineQuery.data.length > 0 ? (
+              <View style={{ gap: spacing[3] }}>
+                {mineQuery.data.map((reward) => (
+                  <RewardCard key={reward.id} reward={reward} />
+                ))}
+              </View>
+            ) : (
+              <EmptyState message={copy.mineEmpty} />
+            )}
+          </Animated.View>
+
+          {/* ── History ── */}
+          <Animated.View entering={entering(3)}>
+            <SectionHead label={copy.historySectionHead} />
+            {historyQuery.isLoading ? (
+              <View style={{ gap: spacing[3] }}>
+                <Skeleton height={48} />
+                <Skeleton height={48} />
+              </View>
+            ) : historyQuery.isError ? (
+              <InlineError text={copy.historyFetchError} onRetry={() => historyQuery.refetch()} />
+            ) : historyQuery.data && historyQuery.data.length > 0 ? (
+              <View style={styles.historyCard}>
+                {historyQuery.data.map((entry, i) => (
+                  <HistoryRow
+                    key={entry.spinId}
+                    entry={entry}
+                    isLast={i === historyQuery.data.length - 1}
+                  />
+                ))}
+              </View>
+            ) : (
+              <EmptyState message={copy.historyEmpty} />
+            )}
+          </Animated.View>
+        </ScrollView>
+      ) : null}
+
+      <SpinResultModal result={modalResult} onClose={closeModal} onShowRewards={showMyRewards} />
+    </Screen>
+  );
+}
+
+function InlineError({ text, onRetry }: { text: string; onRetry: () => void }) {
+  return (
+    <View style={styles.inlineError}>
+      <ThemedText style={styles.errorText}>{text}</ThemedText>
+      <Pressable onPress={onRetry} style={styles.retryButton} accessibilityRole="button">
+        <ThemedText style={styles.retryText}>{copy.retry}</ThemedText>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    height: 48,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255,255,255,0.06)",
+  },
+  backButton: { width: 36, height: 36, alignItems: "center", justifyContent: "center" },
+  headerTitle: {
+    fontSize: 15,
+    fontFamily: fontFamily.bodyBold,
+    letterSpacing: -0.2,
+    color: colors.textPrimary,
+  },
+  content: { padding: spacing[4], paddingBottom: spacing[8], gap: spacing[5] },
+  skeletons: { padding: spacing[4], gap: spacing[4] },
+  center: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing[4],
+    padding: spacing[6],
+  },
+
+  sectionHead: {
+    fontSize: 11,
+    fontFamily: fontFamily.bodySemibold,
+    letterSpacing: 1.5,
+    color: colors.textMuted,
+    marginBottom: spacing[3],
+  },
+
+  pointsCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing[3],
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.22)",
+    borderRadius: radius.card,
+    padding: spacing[4],
+  },
+  pointsIconWrap: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(232,101,10,0.10)",
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.22)",
+  },
+  pointsLabel: { fontSize: 11.5, color: colors.textTertiary },
+  pointsValue: {
+    fontSize: 22,
+    fontFamily: fontFamily.bodyBold,
+    letterSpacing: -0.4,
+    color: colors.textPrimary,
+  },
+  pointsActive: { fontSize: 11.5, color: colors.textTertiary },
+
+  wheelCard: {
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.card,
+    padding: spacing[5],
+    gap: spacing[4],
+  },
+  wheelSubtitle: {
+    fontSize: 12.5,
+    lineHeight: 18,
+    color: colors.textSecondary,
+    textAlign: "center",
+  },
+  spinButton: { alignSelf: "stretch" },
+  primaryButton: {
+    height: 46,
+    borderRadius: radius.card,
+    backgroundColor: colors.accent,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  primaryButtonText: { fontSize: 13.5, fontFamily: fontFamily.bodyBold, color: colors.textPrimary },
+
+  comeBackCard: {
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.card,
+    padding: spacing[6],
+    alignItems: "center",
+    gap: spacing[3],
+  },
+  comeBackIconWrap: {
+    width: 52,
+    height: 52,
+    borderRadius: 26,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(232,101,10,0.10)",
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.22)",
+  },
+  comeBackTitle: {
+    fontSize: 13.5,
+    fontFamily: fontFamily.bodySemibold,
+    color: colors.textPrimary,
+    textAlign: "center",
+  },
+  countdownChip: {
+    borderRadius: 999,
+    paddingHorizontal: spacing[3],
+    paddingVertical: 4,
+    backgroundColor: "rgba(232,101,10,0.10)",
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.22)",
+  },
+  countdownText: { fontSize: 12, fontFamily: fontFamily.bodySemibold, color: colors.accent },
+
+  rewardCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing[3],
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.card,
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[4],
+  },
+  rewardIconWrap: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(232,101,10,0.10)",
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.22)",
+  },
+  rewardIcon: { fontSize: 18, lineHeight: 24 },
+  rewardTitleRow: { flexDirection: "row", alignItems: "center", gap: spacing[2] },
+  rewardTitle: {
+    flexShrink: 1,
+    fontSize: 13.5,
+    fontFamily: fontFamily.bodySemibold,
+    color: colors.textPrimary,
+  },
+  rewardMeta: { marginTop: 2, fontSize: 11.5, color: colors.textTertiary },
+  rewardOpenHint: { marginTop: 2, fontSize: 11.5, color: colors.accent },
+
+  historyCard: {
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.card,
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[4],
+  },
+  historyRow: { flexDirection: "row", gap: spacing[3] },
+  historyRail: { alignItems: "center", width: 12 },
+  historyDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: colors.accent,
+    marginTop: 5,
+  },
+  historyDotMuted: { backgroundColor: "rgba(255,255,255,0.22)" },
+  historyLine: { flex: 1, width: 1, backgroundColor: "rgba(255,255,255,0.08)", marginVertical: 3 },
+  historyBody: { flex: 1, paddingBottom: spacing[4] },
+  historyDate: { fontSize: 11, color: colors.textMuted },
+  historyTitleRow: { flexDirection: "row", alignItems: "center", gap: spacing[2], marginTop: 3 },
+  historyIcon: { fontSize: 14, lineHeight: 18 },
+  historyTitle: {
+    flexShrink: 1,
+    fontSize: 13,
+    fontFamily: fontFamily.bodySemibold,
+    color: colors.textPrimary,
+  },
+
+  statusBadge: { borderRadius: 999, paddingHorizontal: 8, paddingVertical: 2 },
+  statusBadgeText: { fontSize: 10.5, fontFamily: fontFamily.bodySemibold },
+
+  loginText: { fontSize: 13.5, color: colors.textSecondary, textAlign: "center" },
+  errorText: { fontSize: 12.5, color: "#f87171", textAlign: "center" },
+  inlineError: { alignItems: "center", gap: spacing[3], paddingVertical: spacing[4] },
+  retryButton: {
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.35)",
+    backgroundColor: "rgba(232,101,10,0.12)",
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+  },
+  retryText: { fontSize: 12.5, fontFamily: fontFamily.bodySemibold, color: colors.accent },
+});

--- a/features/rewards/SpinNudgeSheet.tsx
+++ b/features/rewards/SpinNudgeSheet.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useState } from "react";
+import { Modal, Pressable, StyleSheet, View } from "react-native";
+import { useRouter } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import Animated, { FadeIn, SlideInDown } from "react-native-reanimated";
+
+import { ThemedText } from "@/components/ui/ThemedText";
+import { useAuth } from "@/services/auth/AuthProvider";
+import { getRewardStatus } from "@/services/api/rewards";
+import { WELCOME_PROMPTED_KEY_PREFIX } from "@/features/coupons/WelcomeCouponModal";
+import { rewardsCopy as copy } from "@/constants/copy";
+import { colors, fontFamily, radius, spacing } from "@/theme";
+
+/**
+ * Weekly-spin launch nudge — a non-blocking bottom sheet shown ONCE per app
+ * launch when the signed-in user has a spin available (canSpin from
+ * GET /api/rewards/status, the same cached query the header uses).
+ *
+ * Once-per-launch is a module-level flag by design (spec: "Do not show
+ * again until next launch") — deliberately NOT persisted, unlike the
+ * welcome modal's per-user AsyncStorage flag.
+ *
+ * First-login coordination: the welcome-coupon modal owns the first launch.
+ * The nudge defers by reading the welcome modal's own prompted flag and
+ * skipping any launch where it hasn't been answered yet — two sheets never
+ * compete for the same moment.
+ */
+
+let shownThisLaunch = false;
+
+/** Test hook — not used in production code. */
+export function resetSpinNudgeForTests() {
+  shownThisLaunch = false;
+}
+
+export function SpinNudgeSheet() {
+  const router = useRouter();
+  const { user } = useAuth();
+  const [visible, setVisible] = useState(false);
+  const [welcomeHandled, setWelcomeHandled] = useState(false);
+
+  const statusQuery = useQuery({
+    queryKey: ["rewards", "status", user?.id ?? null],
+    queryFn: getRewardStatus,
+    enabled: !!user,
+  });
+
+  const userId = user?.id ?? null;
+
+  useEffect(() => {
+    setWelcomeHandled(false);
+    if (!userId) return;
+    let mounted = true;
+    AsyncStorage.getItem(WELCOME_PROMPTED_KEY_PREFIX + userId)
+      .then((flag) => {
+        if (mounted) setWelcomeHandled(flag === "1");
+      })
+      .catch(() => {
+        // Can't read the flag — err on the quiet side and skip the nudge.
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [userId]);
+
+  useEffect(() => {
+    if (shownThisLaunch || visible) return;
+    if (!userId || !welcomeHandled) return;
+    if (statusQuery.data?.canSpin !== true) return;
+    shownThisLaunch = true;
+    setVisible(true);
+  }, [userId, welcomeHandled, statusQuery.data?.canSpin, visible]);
+
+  if (!visible) return null;
+
+  const dismiss = () => setVisible(false);
+  const goSpin = () => {
+    setVisible(false);
+    router.push("/beloningar");
+  };
+
+  return (
+    <Modal visible transparent animationType="none" onRequestClose={dismiss}>
+      {/* Non-blocking: tapping the backdrop dismisses. */}
+      <Animated.View entering={FadeIn.duration(180)} style={styles.backdrop}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={dismiss} accessibilityRole="button" />
+        <Animated.View
+          entering={SlideInDown.springify().damping(19).stiffness(160)}
+          style={styles.sheet}
+        >
+          <View style={styles.handle} />
+          <ThemedText style={styles.title}>{copy.nudgeTitle}</ThemedText>
+          <ThemedText style={styles.body}>{copy.nudgeBody}</ThemedText>
+          <Pressable
+            onPress={goSpin}
+            style={({ pressed }) => [
+              styles.primaryButton,
+              pressed && { backgroundColor: colors.accentHover },
+            ]}
+            accessibilityRole="button"
+          >
+            <ThemedText style={styles.primaryButtonText}>{copy.nudgeSpin}</ThemedText>
+          </Pressable>
+          <Pressable
+            onPress={dismiss}
+            style={({ pressed }) => [styles.secondaryButton, pressed && { opacity: 0.7 }]}
+            accessibilityRole="button"
+          >
+            <ThemedText style={styles.secondaryButtonText}>{copy.nudgeLater}</ThemedText>
+          </Pressable>
+        </Animated.View>
+      </Animated.View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0,0,0,0.55)",
+  },
+  sheet: {
+    backgroundColor: colors.card,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+    borderColor: "rgba(232,101,10,0.22)",
+    paddingHorizontal: spacing[6],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[8],
+    alignItems: "center",
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: "rgba(255,255,255,0.18)",
+    marginBottom: spacing[4],
+  },
+  title: {
+    fontSize: 17,
+    fontFamily: fontFamily.bodyBold,
+    letterSpacing: -0.3,
+    color: colors.textPrimary,
+    textAlign: "center",
+  },
+  body: {
+    marginTop: spacing[2],
+    fontSize: 12.5,
+    lineHeight: 18,
+    color: colors.textSecondary,
+    textAlign: "center",
+  },
+  primaryButton: {
+    alignSelf: "stretch",
+    height: 46,
+    marginTop: spacing[5],
+    borderRadius: radius.card,
+    backgroundColor: colors.accent,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  primaryButtonText: { fontSize: 13.5, fontFamily: fontFamily.bodyBold, color: colors.textPrimary },
+  secondaryButton: {
+    alignSelf: "stretch",
+    height: 44,
+    marginTop: spacing[2],
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  secondaryButtonText: {
+    fontSize: 13.5,
+    fontFamily: fontFamily.bodySemibold,
+    color: colors.textSecondary,
+  },
+});

--- a/features/rewards/SpinResultModal.tsx
+++ b/features/rewards/SpinResultModal.tsx
@@ -1,0 +1,160 @@
+import { Modal, Pressable, StyleSheet, View } from "react-native";
+import Animated, { FadeIn, ZoomIn } from "react-native-reanimated";
+
+import { ThemedText } from "@/components/ui/ThemedText";
+import type { ApiSpinResult } from "@/services/api/rewards";
+import { rewardsCopy as copy } from "@/constants/copy";
+import { colors, fontFamily, radius, spacing } from "@/theme";
+
+/**
+ * Post-spin result modal — shown only after the wheel has settled, with the
+ * server-decided outcome. Premium-minimal: one large icon (the reward's own
+ * emoji as configured by admin), a headline, a short body, and two actions.
+ * Subtle ZoomIn entrance; no confetti/casino styling by design.
+ */
+export function SpinResultModal({
+  result,
+  onClose,
+  onShowRewards,
+}: {
+  result: ApiSpinResult | null;
+  onClose: () => void;
+  onShowRewards: () => void;
+}) {
+  if (!result) return null;
+
+  const isWin = result.resultType !== "NoReward";
+  const headline =
+    result.resultType === "Points"
+      ? copy.modalWinPoints(result.rewardValue ?? "")
+      : result.resultType === "Coupon"
+        ? copy.modalWinCoupon(result.rewardValue ?? "")
+        : copy.modalNoWin;
+  const body =
+    result.resultType === "Points"
+      ? copy.modalPointsBody
+      : result.resultType === "Coupon"
+        ? copy.modalCouponBody
+        : copy.modalNoWinBody;
+
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={onClose}>
+      <Animated.View entering={FadeIn.duration(180)} style={styles.backdrop}>
+        <Animated.View entering={ZoomIn.springify().damping(18).stiffness(180)} style={styles.card}>
+          <View style={styles.iconWrap}>
+            <ThemedText style={styles.icon}>{result.icon || (isWin ? "🎁" : "😔")}</ThemedText>
+          </View>
+
+          <ThemedText style={styles.headline}>{headline}</ThemedText>
+          <ThemedText style={styles.body}>{body}</ThemedText>
+
+          {result.resultType === "Points" ? (
+            <View style={styles.balanceChip}>
+              <ThemedText style={styles.balanceText}>
+                {result.pointsBalance} {copy.pointsUnit}
+              </ThemedText>
+            </View>
+          ) : null}
+
+          <View style={styles.buttons}>
+            {isWin ? (
+              <Pressable
+                onPress={onShowRewards}
+                style={({ pressed }) => [
+                  styles.primaryButton,
+                  pressed && { backgroundColor: colors.accentHover },
+                ]}
+                accessibilityRole="button"
+              >
+                <ThemedText style={styles.primaryButtonText}>{copy.modalShowRewards}</ThemedText>
+              </Pressable>
+            ) : null}
+            <Pressable
+              onPress={onClose}
+              style={({ pressed }) => [styles.secondaryButton, pressed && { opacity: 0.7 }]}
+              accessibilityRole="button"
+            >
+              <ThemedText style={styles.secondaryButtonText}>{copy.modalClose}</ThemedText>
+            </Pressable>
+          </View>
+        </Animated.View>
+      </Animated.View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.72)",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: spacing[6],
+  },
+  card: {
+    width: "100%",
+    maxWidth: 340,
+    backgroundColor: colors.card,
+    borderRadius: radius.card,
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.22)",
+    padding: spacing[6],
+    alignItems: "center",
+  },
+  iconWrap: {
+    width: 88,
+    height: 88,
+    borderRadius: 44,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(232,101,10,0.10)",
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.22)",
+    marginBottom: spacing[4],
+  },
+  icon: { fontSize: 42, lineHeight: 52 },
+  headline: {
+    fontSize: 18,
+    fontFamily: fontFamily.bodyBold,
+    letterSpacing: -0.3,
+    color: colors.textPrimary,
+    textAlign: "center",
+  },
+  body: {
+    marginTop: spacing[2],
+    fontSize: 12.5,
+    lineHeight: 18,
+    color: colors.textSecondary,
+    textAlign: "center",
+  },
+  balanceChip: {
+    marginTop: spacing[3],
+    borderRadius: 999,
+    paddingHorizontal: spacing[3],
+    paddingVertical: 4,
+    backgroundColor: "rgba(74,222,128,0.1)",
+  },
+  balanceText: { fontSize: 12, fontFamily: fontFamily.bodySemibold, color: "#4ade80" },
+  buttons: { alignSelf: "stretch", marginTop: spacing[5], gap: spacing[2] },
+  primaryButton: {
+    height: 46,
+    borderRadius: radius.card,
+    backgroundColor: colors.accent,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  primaryButtonText: { fontSize: 13.5, fontFamily: fontFamily.bodyBold, color: colors.textPrimary },
+  secondaryButton: {
+    height: 44,
+    borderRadius: radius.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  secondaryButtonText: {
+    fontSize: 13.5,
+    fontFamily: fontFamily.bodySemibold,
+    color: colors.textSecondary,
+  },
+});

--- a/features/rewards/SpinResultModal.tsx
+++ b/features/rewards/SpinResultModal.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from "react";
 import { Modal, Pressable, StyleSheet, View } from "react-native";
+import * as Haptics from "expo-haptics";
 import Animated, { FadeIn, ZoomIn } from "react-native-reanimated";
 
 import { ThemedText } from "@/components/ui/ThemedText";
@@ -21,9 +23,17 @@ export function SpinResultModal({
   onClose: () => void;
   onShowRewards: () => void;
 }) {
-  if (!result) return null;
+  const isWin = !!result && result.resultType !== "NoReward";
 
-  const isWin = result.resultType !== "NoReward";
+  // Two-beat feel: the wheel's settle tick (light impact) → a success pulse
+  // as the win reveals. No celebration haptic for no-win, deliberately.
+  useEffect(() => {
+    if (result && isWin) {
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(() => {});
+    }
+  }, [result, isWin]);
+
+  if (!result) return null;
   const headline =
     result.resultType === "Points"
       ? copy.modalWinPoints(result.rewardValue ?? "")
@@ -53,6 +63,10 @@ export function SpinResultModal({
               <ThemedText style={styles.balanceText}>
                 {result.pointsBalance} {copy.pointsUnit}
               </ThemedText>
+            </View>
+          ) : result.resultType === "Coupon" && result.coupon ? (
+            <View style={styles.codeChip}>
+              <ThemedText style={styles.codeText}>{result.coupon.code}</ThemedText>
             </View>
           ) : null}
 
@@ -135,6 +149,21 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(74,222,128,0.1)",
   },
   balanceText: { fontSize: 12, fontFamily: fontFamily.bodySemibold, color: "#4ade80" },
+  codeChip: {
+    marginTop: spacing[3],
+    borderRadius: 999,
+    paddingHorizontal: spacing[3],
+    paddingVertical: 4,
+    backgroundColor: "rgba(232,101,10,0.10)",
+    borderWidth: 1,
+    borderColor: "rgba(232,101,10,0.22)",
+  },
+  codeText: {
+    fontSize: 12,
+    fontFamily: fontFamily.monoMedium,
+    letterSpacing: 0.5,
+    color: colors.accent,
+  },
   buttons: { alignSelf: "stretch", marginTop: spacing[5], gap: spacing[2] },
   primaryButton: {
     height: 46,

--- a/features/rewards/rewardFormat.ts
+++ b/features/rewards/rewardFormat.ts
@@ -1,0 +1,37 @@
+import type { ApiUserReward } from "@/services/api/rewards";
+import { rewardsCopy as copy } from "@/constants/copy";
+
+/** Feature-local formatting shared by the rewards screen sections —
+ * mirrors features/coupons/couponFormat.ts. */
+
+export function formatRewardDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("sv-SE", { day: "numeric", month: "long" });
+}
+
+/** One status-appropriate meta line: validity, redeemed-at or expired-at. */
+export function rewardMetaLine(reward: ApiUserReward): string {
+  if (reward.status === "Redeemed" && reward.redeemedAt)
+    return copy.redeemedAt(formatRewardDate(reward.redeemedAt));
+  if (reward.status === "Expired" && reward.expiresAt)
+    return copy.expiredAt(formatRewardDate(reward.expiresAt));
+  if (reward.expiresAt) return copy.validUntil(formatRewardDate(reward.expiresAt));
+  return copy.wonAt(formatRewardDate(reward.createdAt));
+}
+
+/** Same palette as COUPON_STATUS_COLORS, keyed by UserRewardStatus. */
+export const REWARD_STATUS_COLORS: Record<string, { color: string; bg: string }> = {
+  Unused: { color: "#4ade80", bg: "rgba(74,222,128,0.1)" },
+  Redeemed: { color: "rgba(255,255,255,0.5)", bg: "rgba(255,255,255,0.06)" },
+  Expired: { color: "#f87171", bg: "rgba(248,113,113,0.1)" },
+};
+
+/** Live countdown parts to a future ISO timestamp (clamped at zero). */
+export function countdownParts(untilIso: string): { d: number; h: number; m: number } {
+  const ms = Math.max(0, new Date(untilIso).getTime() - Date.now());
+  const totalMinutes = Math.floor(ms / 60_000);
+  return {
+    d: Math.floor(totalMinutes / (60 * 24)),
+    h: Math.floor((totalMinutes % (60 * 24)) / 60),
+    m: totalMinutes % 60,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo": "^54.0.35",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.12",
+        "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
         "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.12",
@@ -7638,6 +7639,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-15.0.8.tgz",
+      "integrity": "sha512-lftutojy8Qs8zaDzzjwM3gKHFZ8bOOEZDCkmh2Ddpe95Ra6kt2izeOfOfKuP/QEh0MZ1j9TfqippyHdRd1ZM9g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-image": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "expo": "^54.0.35",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.12",
+    "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.12",

--- a/services/api/points.ts
+++ b/services/api/points.ts
@@ -1,0 +1,30 @@
+import { apiClient, requireAuth } from "./client";
+
+/**
+ * Nutri points ledger — client for the backend's PointsController. Shape
+ * copied verbatim from PointsTransactionDto (DTOs/RewardDTOs.cs). The
+ * current balance is NOT fetched here — it already rides along on
+ * GET /api/rewards/status (RewardStatusDto.pointsBalance); one source,
+ * no duplicate endpoint.
+ */
+
+export interface ApiPointsTransaction {
+  id: string;
+  /** Positive = earned. (No spend reasons exist yet — future feature.) */
+  amount: number;
+  /** Enum name: "OrderEarned" | "WeeklyRewardEarned" | future reasons. */
+  reason: string;
+  createdAt: string;
+  orderId: string | null;
+  rewardSpinId: string | null;
+}
+
+/** GET /api/points/transactions — the authenticated user's own ledger,
+ * newest first (latest 100). */
+export async function getMyPointsTransactions(): Promise<ApiPointsTransaction[]> {
+  const { data } = await apiClient.get<ApiPointsTransaction[]>(
+    "/api/points/transactions",
+    requireAuth()
+  );
+  return data;
+}

--- a/services/api/rewards.ts
+++ b/services/api/rewards.ts
@@ -1,0 +1,129 @@
+import { apiClient, requireAuth } from "./client";
+import type { ApiCoupon } from "./coupons";
+
+/**
+ * Weekly reward wheel — client for the backend's RewardsController. Field
+ * shapes copied verbatim from the backend DTO records (DTOs/RewardDTOs.cs) —
+ * never invented:
+ *
+ *   RewardStatusDto(bool CanSpin, DateTime? NextSpinAt, int PointsBalance,
+ *                   int ActiveRewards)
+ *   SpinResultDto(Guid SpinId, string ResultType, string Title, string Icon,
+ *                 string? RewardValue, CouponDto? Coupon, int? PointsAwarded,
+ *                 int PointsBalance, DateTime NextSpinAt)
+ *   UserRewardDto(Guid Id, string RewardType, string Title, string Icon,
+ *                 string? RewardValue, string Status, DateTime CreatedAt,
+ *                 DateTime? ExpiresAt, DateTime? RedeemedAt, Guid? CouponId)
+ *   RewardHistoryEntryDto(Guid SpinId, DateTime SpunAt, string ResultType,
+ *                         string Title, string Icon, string? RewardValue,
+ *                         string? RewardStatus, DateTime? ExpiresAt)
+ *
+ * The BACKEND decides every outcome — POST /spin returns the already-decided
+ * reward and the client wheel animation is purely visual. Coupon wins are
+ * real Coupon rows: they show up in GET /api/coupons and redeem through the
+ * existing checkout flow (CreateOrderDto.CouponId) — no reward-specific
+ * redemption path exists, by design.
+ */
+
+export interface ApiRewardStatus {
+  canSpin: boolean;
+  /** ISO timestamp when the next spin unlocks; null when the user can spin
+   * right now (or has never spun). */
+  nextSpinAt: string | null;
+  pointsBalance: number;
+  /** Count of currently redeemable rewards (unused + unexpired). */
+  activeRewards: number;
+}
+
+export interface ApiWheelSegment {
+  id: string;
+  title: string;
+  icon: string;
+  /** Relative draw weight — slice sizes are rendered proportional to this. */
+  probabilityWeight: number;
+  displayOrder: number;
+}
+
+export interface ApiSpinResult {
+  spinId: string;
+  /** The drawn wheel segment — the wheel lands on the matching slice.
+   * Null if the segment was deleted mid-flight. */
+  weeklyRewardId: string | null;
+  /** "Points" | "Coupon" | "NoReward". */
+  resultType: string;
+  title: string;
+  icon: string;
+  /** Points amount ("50") or coupon percentage ("20"). */
+  rewardValue: string | null;
+  /** The minted coupon for Coupon wins — same shape as GET /api/coupons. */
+  coupon: ApiCoupon | null;
+  pointsAwarded: number | null;
+  /** Balance after the spin (already credited for Points wins). */
+  pointsBalance: number;
+  nextSpinAt: string;
+}
+
+export interface ApiUserReward {
+  id: string;
+  /** "Points" | "Coupon". */
+  rewardType: string;
+  title: string;
+  icon: string;
+  rewardValue: string | null;
+  /** "Unused" | "Redeemed" | "Expired" — effective status (coupon-backed
+   * rewards derive it from the live Coupon row server-side). */
+  status: string;
+  createdAt: string;
+  expiresAt: string | null;
+  redeemedAt: string | null;
+  /** Set for Coupon rewards — open it via the existing /kupong/[id] screen. */
+  couponId: string | null;
+}
+
+export interface ApiRewardHistoryEntry {
+  spinId: string;
+  spunAt: string;
+  /** "Points" | "Coupon" | "NoReward". */
+  resultType: string;
+  title: string;
+  icon: string;
+  rewardValue: string | null;
+  /** Effective status of the granted reward; null for NoReward. */
+  rewardStatus: string | null;
+  expiresAt: string | null;
+}
+
+/** GET /api/rewards/status — everything the header + rewards page need in
+ * one request: canSpin, nextSpinAt, pointsBalance, activeRewards. */
+export async function getRewardStatus(): Promise<ApiRewardStatus> {
+  const { data } = await apiClient.get<ApiRewardStatus>("/api/rewards/status", requireAuth());
+  return data;
+}
+
+/** GET /api/rewards/wheel — the eligible segments (title/icon/weight) so the
+ * wheel renders real slices. Display data only — outcomes stay server-side. */
+export async function getWheelSegments(): Promise<ApiWheelSegment[]> {
+  const { data } = await apiClient.get<ApiWheelSegment[]>("/api/rewards/wheel", requireAuth());
+  return data;
+}
+
+/** POST /api/rewards/spin — one spin per rolling 7 days. The backend rolls
+ * the (weighted) outcome; 409 = already spun this week, 503 = wheel not
+ * configured. Both surface as normalized ApiError via the client. */
+export async function spinRewardWheel(): Promise<ApiSpinResult> {
+  const { data } = await apiClient.post<ApiSpinResult>("/api/rewards/spin", undefined, requireAuth());
+  return data;
+}
+
+/** GET /api/rewards/mine — the user's won rewards, newest first. */
+export async function getMyRewards(): Promise<ApiUserReward[]> {
+  const { data } = await apiClient.get<ApiUserReward[]>("/api/rewards/mine", requireAuth());
+  return data;
+}
+
+/** GET /api/rewards/history — ready-to-render spin history (incl. "no
+ * win"), newest first. The client never joins spins against rewards. */
+export async function getRewardHistory(): Promise<ApiRewardHistoryEntry[]> {
+  const { data } = await apiClient.get<ApiRewardHistoryEntry[]>("/api/rewards/history", requireAuth());
+  return data;
+}


### PR DESCRIPTION
## Syfte
Hela Weekly Rewards-upplevelsen i appen: hjul, belöningar, poäng, launch-nudge och header-entré.

**OBS:** Repot saknar staging-branch — PR:n går mot `main` (repots default). Kräver backend-PR OscarLrsen/Nutri-Backend#19 i miljön.

## Innehåll
- **/beloningar** — poängkort, hjul med riktiga segment (slices proportionella mot ProbabilityWeight, ikon+etikett per slice), Mina belöningar, historik-timeline
- **Hjulet**: naturlig acceleration → cruise medan servern avgör → 4,5 s utrullning som landar på den server-dragna slicen; lätt haptik vid stopp (expo-haptics, nytt beroende); ljud skippat (inget ljudbibliotek)
- **/poang** — Nutri-poäng: saldo + transaktionsledger (nya reasons renderas utan appuppdatering); nav-rad under Mina kuponger
- **SpinNudgeSheet** — premium bottom sheet vid appstart när canSpin, en gång per launch, viker sig för välkomstkupong-modalen
- **Header**: gåvoikon alltid synlig, svävar mjukt + grön prick när spin väntar
- Kupongvinster öppnas via befintliga /kupong/[id] — noll duplicerad UI

## Server är källan
POST /spin avgör allt; hjulet är ren animation. Klienten bestämmer aldrig vinsten.

## Verifiering
lint ✅ · tsc ✅ · expo export (iOS+Android) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)