### PR TITLE
chore(release): configure App Store Connect submit

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -27,7 +27,9 @@
   },
   "submit": {
     "production": {
-      "ascAppId": "6793137228"
+      "ios": {
+        "ascAppId": "6793137228"
+      }
     }
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -26,6 +26,8 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ascAppId": "6793137228"
+    }
   }
 }


### PR DESCRIPTION
Adds the App Store Connect app id to the production submit profile so `eas submit` works non-interactively.

The value is correctly nested under `submit.production.ios.ascAppId`.

Cherry-picked from feat/stamp-card-mobile after PR #3 had already merged. eas.json is the only file touched.

Verification:

* typecheck: pass
* lint: pass
* i18n parity: pass
* swish:check: pass