### PR TITLE
fix: production-ready personalized portions

### DIFF
--- a/context/CartContext.tsx
+++ b/context/CartContext.tsx
@@ -14,9 +14,9 @@ import type { CartItem, Meal, MealSlot } from "@/types/cart";
 import type { ApiDrink } from "@/services/api/drinks";
 import { useLanguage } from "@/i18n";
 import { drinkName } from "@/features/menu/drinkText";
-import { MEAL_SIZES, previewMealPriceOre } from "@/utils/pricing";
+import { MEAL_SIZES } from "@/utils/pricing";
 import { normalizeMacroSnapshot } from "@/utils/macroMath";
-import { getItemMacros, getItemWeightG } from "@/utils/cartMath";
+import { getItemLineTotalOre, getItemMacros, getItemWeightG } from "@/utils/cartMath";
 
 /**
  * Cart store — a port of Nutri-Frontend's src/context/CartContext.tsx, NOT a
@@ -84,7 +84,9 @@ interface CartContextType {
     ingredientSurchargeKr?: number,
     containerTypeId?: string,
     slot?: MealSlot,
-    originalMealName?: string
+    originalMealName?: string,
+    /** Exact backend öre price for a custom line — see CartItem.customPriceOre. */
+    customPriceOre?: number
   ) => void;
   removeItem: (id: string) => void;
   updateQuantity: (id: string, quantity: number) => void;
@@ -299,7 +301,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
       ingredientSurchargeKr?: number,
       containerTypeId?: string,
       slot?: MealSlot,
-      originalMealName?: string
+      originalMealName?: string,
+      customPriceOre?: number
     ) => {
       setItems((prev) => {
         const normalizedCustomMacros = customMacros ? normalizeMacroSnapshot(customMacros) : undefined;
@@ -330,6 +333,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
             customMacros: normalizedCustomMacros,
             customIngredients,
             ingredientSurchargeKr,
+            // Only meaningful on custom lines: a fixed meal's price comes from
+            // basePrice × size and must never be overridden by a caller.
+            customPriceOre: isCustom ? customPriceOre : undefined,
             containerTypeId,
             slot,
             originalMealName,
@@ -442,22 +448,16 @@ export function CartProvider({ children }: { children: ReactNode }) {
 
   const clearCart = useCallback(() => setItems([]), []);
 
-  // Web-identical totals. Fixed meals (no custom builder, no surcharge) use
-  // the backend's whole-SEK öre rounding so the cart total matches
-  // LineTotalOre on the receipt; custom lines keep the float approximation —
-  // backend recomputes pricing for those flows.
-  const totalPrice = items.reduce((sum, item) => {
-    if (item.kind === "drink" && item.drink) {
-      return sum + (item.drink.priceOre / 100) * item.quantity;
-    }
-    const size = MEAL_SIZES.find((s) => s.id === item.sizeId);
-    const multiplier = size?.priceMultiplier ?? 1;
-    const surcharge = item.ingredientSurchargeKr ?? 0;
-    if (!item.isCustom && surcharge === 0) {
-      return sum + (previewMealPriceOre(item.meal.basePrice, multiplier) * item.quantity) / 100;
-    }
-    return sum + (item.meal.basePrice * multiplier + surcharge) * item.quantity;
-  }, 0);
+  // One pricing authority: getItemLineTotalOre (utils/cartMath) prices every
+  // line in integer öre — fixed meals via the backend's whole-SEK rounding,
+  // drinks via their öre price, and custom/personalized lines via the EXACT
+  // backend customPriceOre (18586 stays 18586, never 18600). Legacy persisted
+  // custom lines without the field keep the historical surcharge formula.
+  // Summing integers means the subtotal can no longer drift from the lines.
+  const cartTotalOre = items.reduce((sum, item) => sum + getItemLineTotalOre(item), 0);
+  /** Kronor (float) — kept for the web-identical API surface; derived from
+   * the exact öre sum rather than summed in kronor. */
+  const totalPrice = cartTotalOre / 100;
 
   const totalItems = items.reduce((sum, item) => sum + item.quantity, 0);
 
@@ -479,7 +479,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
     return { macro, weightG };
   }, [items]);
 
-  const subtotalOre = Math.round(totalPrice * 100);
+  // Already an exact integer — no float round-trip.
+  const subtotalOre = cartTotalOre;
 
   return (
     <CartContext.Provider

--- a/features/anpassar/NutriAnpassarScreen.tsx
+++ b/features/anpassar/NutriAnpassarScreen.tsx
@@ -194,8 +194,9 @@ export function NutriAnpassarScreen() {
       name: i.name,
       amountG: i.amountG,
     }));
-    // Cart price formula is basePrice * multiplier + surcharge.
-    // medium multiplier = 1.0, so surcharge reconciles to calcResult.totalPriceOre.
+    // Legacy reconciliation term only — the cart prices this line from the
+    // EXACT customPriceOre below; the rounded surcharge remains for carts
+    // persisted before that field existed.
     const ingredientSurchargeKr = Math.round(calcResult.totalPriceOre / 100) - meal.basePrice;
 
     addItem(
@@ -207,7 +208,8 @@ export function NutriAnpassarScreen() {
       ingredientSurchargeKr,
       containerTypeId,
       undefined,
-      meal.name
+      meal.name,
+      calcResult.totalPriceOre
     );
     router.push("/(tabs)/varukorg");
   }

--- a/features/anpassar/NutriAnpassarScreen.tsx
+++ b/features/anpassar/NutriAnpassarScreen.tsx
@@ -181,7 +181,11 @@ export function NutriAnpassarScreen() {
     calcResult: CustomMealCalculateResponse
   ) {
     const meal = apiMealToMeal(apiMeal);
-    const sizeId = "medium"; // Anpassar always tailors at the medium (1.0×) size
+    // Semantically correct, not a hardcode-in-disguise: the wizard has no M/L
+    // choice — it tailors exactly one portion at the 1.0× (medium) target, so
+    // "medium" IS the size of the portion it builds. The menu's M/L flow
+    // passes the customer's actual selection instead.
+    const sizeId = "medium";
     const customMacros = {
       calories: Math.round(calcResult.totalKcal),
       proteinG: Math.round(calcResult.totalProteinG),

--- a/features/cart/CartScreen.tsx
+++ b/features/cart/CartScreen.tsx
@@ -35,7 +35,8 @@ import { getStoreStatus } from "@/services/api/store";
 import { createOrder, createCheckoutSession } from "@/services/api/orders";
 import { getMyCoupons, isCouponUsable, type ApiCoupon } from "@/services/api/coupons";
 import type { CartItem } from "@/types/cart";
-import { CUSTOMER_SIZE_OPTIONS, MEAL_SIZES, previewMealPriceOre } from "@/utils/pricing";
+import { CUSTOMER_SIZE_OPTIONS, MEAL_SIZES } from "@/utils/pricing";
+import { getItemLineTotalOre, getItemUnitPriceOre } from "@/utils/cartMath";
 import { formatPriceKr, krToOre } from "@/utils/money";
 import { applyDiscountPreview } from "@/utils/discountMath";
 import { normalizeMacroSnapshot } from "@/utils/macroMath";
@@ -893,7 +894,6 @@ function CartItemCard({ item }: { item: CartItem }) {
 
   const isDrink = item.kind === "drink";
   const size = isDrink ? undefined : MEAL_SIZES.find((s) => s.id === item.sizeId);
-  const multiplier = size?.priceMultiplier ?? 1;
 
   // The synthetic Meal wrapper on a drink line snapshots the Swedish name at
   // add time, so rendering item.meal.name directly would freeze the language
@@ -903,19 +903,12 @@ function CartItemCard({ item }: { item: CartItem }) {
   const displayName = isDrink && item.drink ? drinkName(item.drink, language) : item.meal.name;
   const macroMult = size?.macroMultiplier ?? 1;
   const surcharge = item.ingredientSurchargeKr ?? 0;
-  // Fixed meal: keep the cart preview in lockstep with the backend's öre
-  // rounding. Custom/Nutri Anpassar keeps its float approximation since the
-  // backend recomputes that path. (Verbatim web logic.)
-  const isFixedMeal = !isDrink && !item.isCustom && surcharge === 0;
-  const unitPriceKr =
-    isDrink && item.drink
-      ? item.drink.priceOre / 100
-      : isFixedMeal
-        ? previewMealPriceOre(item.meal.basePrice, multiplier) / 100
-        : item.meal.basePrice * multiplier + surcharge;
-  const linePriceKr = isFixedMeal
-    ? (previewMealPriceOre(item.meal.basePrice, multiplier) * item.quantity) / 100
-    : unitPriceKr * item.quantity;
+  // One pricing authority (utils/cartMath): the row and CartContext's summary
+  // price every line through the same function, so they cannot disagree.
+  // Custom/personalized lines carry the backend's exact öre price; fixed
+  // meals keep the backend's whole-SEK rounding; drinks their öre price.
+  const unitPriceOre = getItemUnitPriceOre(item);
+  const linePriceOre = getItemLineTotalOre(item);
 
   const macros =
     item.isCustom && item.customMacros
@@ -999,10 +992,10 @@ function CartItemCard({ item }: { item: CartItem }) {
             </View>
 
             <View style={styles.itemPriceRow}>
-              <ThemedText style={styles.linePrice}>{formatPriceKr(krToOre(linePriceKr), language)}</ThemedText>
+              <ThemedText style={styles.linePrice}>{formatPriceKr(linePriceOre, language)}</ThemedText>
               {item.quantity > 1 && (
                 <ThemedText style={styles.unitPrice}>
-                  {formatPriceKr(krToOre(unitPriceKr), language)} × {item.quantity}
+                  {formatPriceKr(unitPriceOre, language)} × {item.quantity}
                 </ThemedText>
               )}
             </View>

--- a/features/heldag/HeldagScreen.tsx
+++ b/features/heldag/HeldagScreen.tsx
@@ -19,7 +19,7 @@ import { getTodayDayPlan } from "@/services/api/dayPlan";
 import { SLOT_TO_MEAL_TIME_TAG, type WizardSlot } from "@/features/anpassar/optimizer";
 import { OnboardingGate } from "@/features/anpassar/NutriAnpassarScreen";
 import { apiMealToMeal } from "@/utils/pricing";
-import { formatPriceKr, krToOre } from "@/utils/money";
+import { formatPriceKr } from "@/utils/money";
 import { NUTRITION_ONBOARDING_ROUTE } from "@/features/onboarding/nutritionOnboardingRoute";
 import { formatNumber, useLanguage, useTranslation } from "@/i18n";
 import { colors, fontFamily, spacing } from "@/theme";
@@ -186,17 +186,19 @@ export function HeldagScreen() {
     if (!results) return null;
     let kcal = 0,
       protein = 0,
-      kr = 0;
+      // Summed in exact öre — rounding each slot to kronor first let the
+      // package header disagree with the cart total by up to 3×50 öre.
+      ore = 0;
     let readyCount = 0;
     for (const r of results) {
       if (r.status === "ready") {
         kcal += r.customMacros.calories;
         protein += r.customMacros.proteinG;
-        kr += Math.round(r.calcResult.totalPriceOre / 100);
+        ore += r.calcResult.totalPriceOre;
         readyCount++;
       }
     }
-    return { kcal, protein, kr, readyCount };
+    return { kcal, protein, ore, readyCount };
   }, [results]);
 
   const allReady = !!results && results.every((r) => r.status === "ready");
@@ -278,7 +280,12 @@ export function HeldagScreen() {
       r.ingredientSurchargeKr,
       r.containerTypeId,
       r.slot,
-      originalMealName
+      originalMealName,
+      // The slot's EXACT backend price. Notably the legacy surcharge above is
+      // clamped with Math.max(0, …), so a personal portion cheaper than the
+      // base price used to be silently priced UP to base — this fixes that
+      // case too, not just the öre rounding.
+      r.calcResult.totalPriceOre
     );
   }
 
@@ -442,7 +449,7 @@ export function HeldagScreen() {
               <SummaryCell label={t("heldag.summaryKcalTotal")} value={formatNumber(totals.kcal, language)} accent />
               <SummaryCell label={t("heldag.summaryProtein")} value={String(totals.protein)} unit="g" valueColor={colors.accent} />
               <SummaryCell label={t("heldag.summaryMeals")} value={String(SLOTS.length)} unit={t("heldag.unitCount")} accent />
-              <SummaryCell label={t("heldag.summaryPrice")} value={formatNumber(totals.kr, language)} unit="kr" />
+              <SummaryCell label={t("heldag.summaryPrice")} value={formatPriceKr(totals.ore, language).replace(" kr", "")} unit="kr" />
             </View>
           </View>
         )}
@@ -502,7 +509,7 @@ export function HeldagScreen() {
           </View>
           {available && (
             <ThemedText style={styles.ctaPrice}>
-              {formatPriceKr(krToOre(totals ? totals.kr : 0), language)}
+              {formatPriceKr(totals ? totals.ore : 0, language)}
             </ThemedText>
           )}
         </Pressable>
@@ -618,7 +625,9 @@ function SlotCard({
     );
   }
 
-  const priceKr = Math.round(result.calcResult.totalPriceOre / 100);
+  // Exact backend öre — the same number the cart line will carry. The " kr"
+  // suffix is stripped because this layout renders the unit in its own style.
+  const priceValue = formatPriceKr(result.calcResult.totalPriceOre, language).replace(" kr", "");
   const image = result.meal.image && result.meal.image.trim().length > 0 ? result.meal.image : undefined;
 
   return (
@@ -629,7 +638,7 @@ function SlotCard({
         <View style={styles.slotTitleRow}>
           <ThemedText style={styles.slotMealName}>{result.meal.name}</ThemedText>
           <ThemedText style={styles.slotPrice}>
-            {formatNumber(priceKr, language)}
+            {priceValue}
             <ThemedText style={styles.slotPriceUnit}> kr</ThemedText>
           </ThemedText>
         </View>

--- a/features/heldag/HeldagScreen.tsx
+++ b/features/heldag/HeldagScreen.tsx
@@ -273,6 +273,9 @@ export function HeldagScreen() {
     const originalMealName = `${r.slot} · ${t("heldag.packageKitchenName")} · ${r.meal.name}`;
     addItem(
       apiMealToMeal(r.meal),
+      // Semantically correct: the day package offers no M/L choice — each slot
+      // is tailored at its own 1.0× slot target, which is the medium size by
+      // definition. The menu's M/L flow passes the real selection instead.
       "medium",
       1,
       r.customMacros,

--- a/features/menu/MealCard.tsx
+++ b/features/menu/MealCard.tsx
@@ -16,6 +16,7 @@ import { useLanguage, useTranslation } from "@/i18n";
 import { colors, fontFamily, radius, spacing } from "@/theme";
 import type { MealRecommendation } from "./mealRecommendation";
 import { usePersonalizedMeal } from "./personalizedMenu";
+import { arePersonalSizesEquivalent } from "./portionEquivalence";
 
 /**
  * Meal card — mobile port of the web /meny page's MealCard. Logic (per-size
@@ -121,8 +122,37 @@ export function MealCard({ meal, availability, recommendation = null }: MealCard
   // customer's target at the selected size. Static values are shown only
   // when personalization does not apply (logged out, fixed portion,
   // incomplete profile) — never silently in place of a personal price.
-  const personal = usePersonalizedMeal(meal, effectiveSize);
+  //
+  // BOTH sizes are computed (not just the selected one) because the card
+  // must know whether L is genuinely a different portion before offering
+  // it: when every ingredient is already saturated at max for M, the L
+  // optimization returns the exact same grams and "L" would be a fake
+  // upgrade. The queries are cached per (user, target, meal, size) with a
+  // 5-min staleTime and shared with MealDetailScreen, so this is one extra
+  // calculate call per card, not per render.
+  const personalMedium = usePersonalizedMeal(meal, "medium");
+  const personalLarge = usePersonalizedMeal(meal, "large");
+  const personal = effectiveSize === "large" ? personalLarge : personalMedium;
   const personalData = personal.status === "ready" ? personal.data : null;
+
+  // L is hidden only on CONFIRMED equivalence (both sizes computed and the
+  // ingredient grams exactly equal) — never on a guess while one loads.
+  const sizesEquivalent = arePersonalSizesEquivalent(personalMedium, personalLarge);
+
+  // If the customer had L selected when the results proved L identical to M,
+  // move them to M — the option they were on no longer exists, and M's data
+  // is byte-identical anyway. Deliberately ignores userTouchedSizeRef: this
+  // is not a recommendation stealing a choice, it is removing a non-choice.
+  useEffect(() => {
+    if (sizesEquivalent && selectedSize === "large") setSelectedSize("medium");
+  }, [sizesEquivalent, selectedSize]);
+
+  // While the SELECTED size's personal computation is in flight, adding is
+  // paused: the button would otherwise add the static recipe portion as if
+  // it were the personal one. "error" deliberately does NOT pause — the card
+  // says outright that the ordinary price is shown, so adding the static
+  // portion is honest there.
+  const personalAddPending = personal.status === "loading";
 
   const calories = personalData
     ? Math.round(personalData.calc.totalKcal)
@@ -159,7 +189,7 @@ export function MealCard({ meal, availability, recommendation = null }: MealCard
   const showImage = !imageFailed && meal.image.trim().length > 0;
 
   const handleAdd = () => {
-    if (stockLocked || addLockedRef.current) return;
+    if (stockLocked || addLockedRef.current || personalAddPending) return;
 
     // Same cart mapping and selected-size contract as MealDetailScreen.
     addLockedRef.current = true;
@@ -171,7 +201,10 @@ export function MealCard({ meal, availability, recommendation = null }: MealCard
       // order endpoint recomputes and validates the price server-side.
       addItem(
         apiMealToMeal(meal),
-        "medium",
+        // The size the customer actually chose — a personal L used to be
+        // stored (and ordered) as "medium", which the kitchen then plated
+        // as an M.
+        effectiveSize,
         1,
         {
           calories: Math.round(personalData.calc.totalKcal),
@@ -337,7 +370,10 @@ export function MealCard({ meal, availability, recommendation = null }: MealCard
       <View style={styles.footer}>
         {!isFixed ? (
           <View style={styles.sizeGroup}>
-            {CUSTOMER_SIZE_OPTIONS.map((s) => {
+            {/* When personal M and L are provably the same portion, L is not
+                rendered — a second button for the identical recipe would be a
+                fake choice. Static (non-personalized) cards never filter. */}
+            {CUSTOMER_SIZE_OPTIONS.filter((s) => !(sizesEquivalent && s.id === "large")).map((s) => {
               const isSelected = selectedSize === s.id;
               const sSoldOut = stockBySize[s.id as "medium" | "large"].soldOut;
               const isRec = hasRecommendation && s.id === recSizeId;
@@ -385,15 +421,15 @@ export function MealCard({ meal, availability, recommendation = null }: MealCard
 
         <Pressable
           onPress={handleAdd}
-          disabled={stockLocked || added}
+          disabled={stockLocked || added || personalAddPending}
           style={({ pressed }) => [
             styles.addButton,
             added && styles.addButtonAdded,
-            stockLocked && styles.addButtonLocked,
-            pressed && !added && !stockLocked && styles.addButtonPressed,
+            (stockLocked || personalAddPending) && styles.addButtonLocked,
+            pressed && !added && !stockLocked && !personalAddPending && styles.addButtonPressed,
           ]}
           accessibilityRole="button"
-          accessibilityState={{ disabled: stockLocked || added }}
+          accessibilityState={{ disabled: stockLocked || added || personalAddPending }}
           accessibilityLabel={
             stockLocked ? t("menu.soldOutToday") : added ? t("menu.added") : t("mealDetail.add")
           }

--- a/features/menu/MealCard.tsx
+++ b/features/menu/MealCard.tsx
@@ -164,11 +164,11 @@ export function MealCard({ meal, availability, recommendation = null }: MealCard
     // Same cart mapping and selected-size contract as MealDetailScreen.
     addLockedRef.current = true;
     if (personalData) {
-      // The personally computed line — the SAME tailored handoff the
-      // Anpassar wizard used: the server's macros and ingredient grams, and
-      // a surcharge that reconciles the cart preview to the server's
-      // öre-precise price. The order endpoint recomputes and validates the
-      // price server-side either way.
+      // The personally computed line: the server's macros and grams, and the
+      // server's EXACT öre price (customPriceOre) — the same number this card
+      // displays, so the cart can never show a different total than the menu
+      // promised. surchargeKr rides along for legacy compatibility only. The
+      // order endpoint recomputes and validates the price server-side.
       addItem(
         apiMealToMeal(meal),
         "medium",
@@ -189,6 +189,7 @@ export function MealCard({ meal, availability, recommendation = null }: MealCard
         personalData.containerTypeId,
         undefined,
         meal.name,
+        personalData.calc.totalPriceOre,
       );
     } else {
       addItem(apiMealToMeal(meal), effectiveSize);

--- a/features/menu/MealDetailScreen.tsx
+++ b/features/menu/MealDetailScreen.tsx
@@ -21,6 +21,7 @@ import { sortIngredientsByAmount } from "@/utils/ingredientOrder";
 import { useLanguage, useTranslation } from "@/i18n";
 import { colors, fontFamily, radius, spacing } from "@/theme";
 import { usePersonalizedMeal } from "./personalizedMenu";
+import { arePersonalSizesEquivalent } from "./portionEquivalence";
 
 /**
  * Meal detail — mobile port of the web (customer)/meal/[id]/page.tsx,
@@ -140,6 +141,24 @@ export function MealDetailScreen() {
     return state.status === "ready" ? state.data : null;
   };
 
+  // Same shared rule as MealCard: L is hidden only when both personal sizes
+  // are computed AND their ingredient grams are exactly identical — a second
+  // option for the same recipe is a fake choice. Confirmed equivalence only;
+  // totals are never compared (the price floor can equalize prices of
+  // genuinely different portions, and those must both stay offered).
+  const sizesEquivalent = arePersonalSizesEquivalent(personalMedium, personalLarge);
+
+  useEffect(() => {
+    if (sizesEquivalent && selectedSize === "large") setSelectedSize("medium");
+  }, [sizesEquivalent, selectedSize]);
+
+  // While the SELECTED size's personal result is in flight the CTA pauses —
+  // it would otherwise add the static recipe portion as if it were the
+  // personal one. "error" does not pause: the screen states outright that
+  // static values are shown, so adding them is honest. Non-personalized
+  // customers ("off"/"incomplete") are unaffected.
+  const personalAddPending = personal.status === "loading";
+
   const macros = useMemo(() => {
     if (!meal) return null;
     if (personalData) {
@@ -196,7 +215,7 @@ export function MealDetailScreen() {
 
   // Same guard + call + 1.8s confirmation as the web page's handleAdd.
   const handleAdd = () => {
-    if (!meal || stockLocked) return;
+    if (!meal || stockLocked || personalAddPending) return;
     if (personalData) {
       // Server macros and grams, and the server's EXACT öre price
       // (customPriceOre) — the same number this page displays, so the cart
@@ -205,7 +224,9 @@ export function MealDetailScreen() {
       // recomputes and validates the price server-side.
       addItem(
         apiMealToMeal(meal),
-        "medium",
+        // The size the customer actually chose — a personal L used to be
+        // stored (and ordered) as "medium".
+        effectiveSize,
         quantity,
         {
           calories: Math.round(personalData.calc.totalKcal),
@@ -412,7 +433,7 @@ export function MealDetailScreen() {
               <Divider />
               <SectionHead>{t("mealDetail.chooseSize")}</SectionHead>
               <View style={styles.sizeList}>
-                {CUSTOMER_SIZE_OPTIONS.map((s) => {
+                {CUSTOMER_SIZE_OPTIONS.filter((s) => !(sizesEquivalent && s.id === "large")).map((s) => {
                   const isSel = selectedSize === s.id;
                   const sStock = stockBySize[s.id as "medium" | "large"];
                   const sSoldOut = sStock?.soldOut ?? false;
@@ -587,13 +608,14 @@ export function MealDetailScreen() {
 
         <Pressable
           onPress={handleAdd}
-          disabled={stockLocked}
+          disabled={stockLocked || personalAddPending}
           style={({ pressed }) => [
             styles.cta,
-            stockLocked && styles.ctaLocked,
-            pressed && !stockLocked && { backgroundColor: colors.accentHover },
+            (stockLocked || personalAddPending) && styles.ctaLocked,
+            pressed && !stockLocked && !personalAddPending && { backgroundColor: colors.accentHover },
           ]}
           accessibilityRole="button"
+          accessibilityState={{ disabled: stockLocked || personalAddPending }}
           accessibilityLabel={t("mealDetail.add")}
         >
           {allSoldOut ? (

--- a/features/menu/MealDetailScreen.tsx
+++ b/features/menu/MealDetailScreen.tsx
@@ -133,8 +133,10 @@ export function MealDetailScreen() {
   const personalLarge = usePersonalizedMeal(meal, "large");
   const personal = effectiveSize === "large" ? personalLarge : personalMedium;
   const personalData = personal.status === "ready" ? personal.data : null;
+  const personalStateFor = (sizeId: string) =>
+    sizeId === "large" ? personalLarge : personalMedium;
   const personalFor = (sizeId: string) => {
-    const state = sizeId === "large" ? personalLarge : personalMedium;
+    const state = personalStateFor(sizeId);
     return state.status === "ready" ? state.data : null;
   };
 
@@ -174,12 +176,15 @@ export function MealDetailScreen() {
   }, [meal, ingredientsQuery.data]);
 
   // Öre all the way; formatted only at render (web computes the same product).
-  // The personal price (backend-computed) wins whenever it exists.
+  // The personal price (backend-computed) wins whenever it exists, and while
+  // it is being computed the CTA shows a placeholder instead of letting the
+  // static price pose as the personal one (same rule as MealCard).
   const totalOre = meal
     ? (personalData
         ? personalData.calc.totalPriceOre
         : previewMealPriceOre(meal.basePrice, sizeDef.priceMultiplier)) * quantity
     : 0;
+  const totalPriceLoading = personal.status === "loading";
 
   const selected = stockBySize[effectiveSize as "medium" | "large"] ?? { soldOut: false, count: null };
   const showLowStock =
@@ -193,9 +198,11 @@ export function MealDetailScreen() {
   const handleAdd = () => {
     if (!meal || stockLocked) return;
     if (personalData) {
-      // The tailored handoff the Anpassar wizard used: server macros and
-      // grams, surcharge reconciling to the server's öre price. The order
-      // endpoint recomputes and validates the price server-side.
+      // Server macros and grams, and the server's EXACT öre price
+      // (customPriceOre) — the same number this page displays, so the cart
+      // total always equals the price the customer accepted here. surchargeKr
+      // rides along for legacy compatibility only; the order endpoint
+      // recomputes and validates the price server-side.
       addItem(
         apiMealToMeal(meal),
         "medium",
@@ -216,6 +223,7 @@ export function MealDetailScreen() {
         personalData.containerTypeId,
         undefined,
         meal.name,
+        personalData.calc.totalPriceOre,
       );
     } else {
       addItem(apiMealToMeal(meal), effectiveSize, quantity);
@@ -412,8 +420,13 @@ export function MealDetailScreen() {
                   const sShowLow =
                     !sSoldOut && sCount !== null && sCount > 0 && sCount <= LOW_STOCK_THRESHOLD;
                   // The personally computed price/weight for THIS size when
-                  // the engine has it — the static preview only otherwise.
+                  // the engine has it. While a size's personal price is still
+                  // being computed its row shows a placeholder — the static
+                  // price must never masquerade as a definitive personal one,
+                  // and mixing personal-M with static-L on one screen is
+                  // exactly the confusion that rule exists to prevent.
                   const sizePersonal = personalFor(s.id);
+                  const sizePriceLoading = personalStateFor(s.id).status === "loading";
                   const sizePriceOre = sizePersonal
                     ? sizePersonal.calc.totalPriceOre
                     : previewMealPriceOre(meal.basePrice, s.priceMultiplier);
@@ -472,7 +485,7 @@ export function MealDetailScreen() {
                           sSoldOut && { opacity: 0.5 },
                         ]}
                       >
-                        {formatPriceKr(sizePriceOre, language)}
+                        {sizePriceLoading ? "…" : formatPriceKr(sizePriceOre, language)}
                       </ThemedText>
                     </Pressable>
                   );
@@ -603,7 +616,9 @@ export function MealDetailScreen() {
                   ? t("mealDetail.addWithStock", { count: selected.count })
                   : t("mealDetail.add")}
               </ThemedText>
-              <ThemedText style={styles.ctaPrice}>{formatPriceKr(totalOre, language)}</ThemedText>
+              <ThemedText style={styles.ctaPrice}>
+                {totalPriceLoading ? "…" : formatPriceKr(totalOre, language)}
+              </ThemedText>
             </>
           )}
         </Pressable>

--- a/features/menu/portionEquivalence.ts
+++ b/features/menu/portionEquivalence.ts
@@ -1,0 +1,63 @@
+/**
+ * Are two personally computed portions THE SAME portion?
+ *
+ * WHY THIS EXISTS. The menu offers M and L, and each runs the same
+ * optimize→calculate pipeline against a size-scaled target. When every
+ * scalable ingredient is already saturated at its MaxAmountG for M, scaling
+ * the target by 1.2 changes nothing — the optimizer returns the exact same
+ * grams, so weight, macros and price are identical too. Presenting that as
+ * two different purchase options sells the customer an upgrade that does not
+ * exist. These helpers are the single definition of "identical" so MealCard
+ * and MealDetailScreen can never disagree about it.
+ *
+ * THE RULE IS THE RECIPE, NOT THE TOTALS. Two portions are equivalent only
+ * when they contain exactly the same ingredients at exactly the same grams,
+ * regardless of array order. Totals are deliberately NOT compared:
+ *  - equal totalPriceOre does NOT mean equal portions — the minimum price
+ *    floor can price two genuinely different portions identically, and the
+ *    customer still gets more food in one of them;
+ *  - equal weight/calories does not either — two different gram
+ *    distributions can coincide on any aggregate.
+ */
+
+import type { PersonalizedMealState } from "./personalizedMenu";
+
+/** The minimal shape compared — structurally satisfied by OptIngredient. */
+export type PortionIngredient = { ingredientId: string; amountG: number };
+export type PortionLike = { ingredients: PortionIngredient[] };
+
+export function areCustomMealPortionsEquivalent(a: PortionLike, b: PortionLike): boolean {
+  if (a.ingredients.length !== b.ingredients.length) return false;
+
+  // ingredientId → grams, order-independent. Duplicate ids cannot occur in an
+  // optimizer result (one row per library ingredient), but summing makes the
+  // comparison correct even if one ever did.
+  const gramsById = new Map<string, number>();
+  for (const ing of a.ingredients) {
+    gramsById.set(ing.ingredientId, (gramsById.get(ing.ingredientId) ?? 0) + ing.amountG);
+  }
+
+  const seen = new Set<string>();
+  for (const ing of b.ingredients) {
+    if (seen.has(ing.ingredientId)) {
+      // b repeats an id that a listed once — lengths matched, so recipes differ.
+      return false;
+    }
+    seen.add(ing.ingredientId);
+    if (gramsById.get(ing.ingredientId) !== ing.amountG) return false;
+  }
+  return gramsById.size === seen.size;
+}
+
+/**
+ * The screen-level question: with both personal sizes computed, is L the same
+ * portion as M? False whenever either side is not ready — an option is only
+ * hidden on CONFIRMED equivalence, never on a guess while one size loads.
+ */
+export function arePersonalSizesEquivalent(
+  medium: PersonalizedMealState,
+  large: PersonalizedMealState,
+): boolean {
+  if (medium.status !== "ready" || large.status !== "ready") return false;
+  return areCustomMealPortionsEquivalent(medium.data, large.data);
+}

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "swish:check": "node scripts/check-swish-disabled.mjs",
     "pricing:check": "node scripts/check-custom-meal-pricing.mjs",
     "sizes:check": "node scripts/check-portion-sizes.mjs",
+    "limits:check": "node scripts/check-ingredient-limits.mjs",
     "doctor": "expo-doctor"
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "typecheck": "tsc --noEmit",
     "i18n:check": "node scripts/check-i18n-parity.mjs",
     "swish:check": "node scripts/check-swish-disabled.mjs",
+    "pricing:check": "node scripts/check-custom-meal-pricing.mjs",
     "doctor": "expo-doctor"
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "i18n:check": "node scripts/check-i18n-parity.mjs",
     "swish:check": "node scripts/check-swish-disabled.mjs",
     "pricing:check": "node scripts/check-custom-meal-pricing.mjs",
+    "sizes:check": "node scripts/check-portion-sizes.mjs",
     "doctor": "expo-doctor"
   },
   "private": true

--- a/scripts/check-custom-meal-pricing.mjs
+++ b/scripts/check-custom-meal-pricing.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Pricing guard: custom/personalized meals keep the backend's EXACT öre price
+ * through the cart.
+ *
+ * WHY THIS EXISTS. The cart used to rebuild a custom line's price from a
+ * whole-kronor surcharge, so the server's 18586 öre displayed and summed as
+ * 18600 — the shown total could differ from what the backend charges. The fix
+ * routes every cart line through utils/cartMath's getItemUnitPriceOre /
+ * getItemLineTotalOre with an exact customPriceOre carried on the line.
+ *
+ * This script tests THE REAL SOURCE, not a re-implementation: it transpiles
+ * utils/pricing.ts and utils/cartMath.ts with the project's own TypeScript
+ * compiler (type-only imports erase; the one value import is re-pointed),
+ * imports the result, and asserts the numbers. It then asserts the wiring —
+ * that CartContext/CartScreen actually use the helpers and that every
+ * personalized add-site passes totalPriceOre — so the tested function cannot
+ * silently stop being the one in use.
+ *
+ * Run: npm run pricing:check   (no Expo/Metro, no network)
+ */
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+
+const failures = [];
+const check = (name, actual, expected) => {
+  if (actual !== expected) failures.push(`${name}: fick ${actual}, förväntade ${expected}`);
+};
+
+// ── Transpile the real modules ──────────────────────────────────────────
+const outDir = mkdtempSync(join(tmpdir(), "nutri-pricing-"));
+const transpile = (srcPath, outName, rewrites = {}) => {
+  let source = readFileSync(srcPath, "utf8");
+  const js = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 },
+  }).outputText;
+  let output = js;
+  for (const [from, to] of Object.entries(rewrites)) output = output.replaceAll(from, to);
+  const outPath = join(outDir, outName);
+  writeFileSync(outPath, output);
+  return outPath;
+};
+
+transpile("utils/pricing.ts", "pricing.mjs");
+const cartMathPath = transpile("utils/cartMath.ts", "cartMath.mjs", {
+  '"@/utils/pricing"': '"./pricing.mjs"',
+});
+
+const { getItemUnitPriceOre, getItemLineTotalOre } = await import(pathToFileURL(cartMathPath).href);
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+const meal = (basePrice) => ({
+  id: "m1", name: "Test", description: "", image: "", basePrice, category: "Bowls",
+  available: true, macros: { calories: 0, proteinG: 0, carbsG: 0, fatG: 0, fiberG: 0 },
+  ingredients: [], sizes: [],
+});
+
+const customLine = (priceOre, quantity = 1) => ({
+  id: "m1-custom-x", meal: meal(139), sizeId: "medium", quantity,
+  isCustom: true, ingredientSurchargeKr: 47, customPriceOre: priceOre,
+});
+
+// ── 1–2. Exact öre survives, and multiplies exactly ─────────────────────
+check("custom 18586 behålls exakt", getItemUnitPriceOre(customLine(18586)), 18586);
+check("custom 18586 blir INTE 18600", getItemUnitPriceOre(customLine(18586)) === 18600, false);
+check("quantity 2 → 37172", getItemLineTotalOre(customLine(18586, 2)), 37172);
+
+// ── 3. Two different customs sum exactly in öre ─────────────────────────
+const sum = getItemLineTotalOre(customLine(18586)) + getItemLineTotalOre(customLine(12233));
+check("18586 + 12233 = 30819", sum, 30819);
+
+// ── 4. Fixed meals: historical whole-SEK behaviour untouched ────────────
+const fixedLine = (basePrice, sizeId, quantity = 1) => ({
+  id: `m1-${sizeId}`, meal: meal(basePrice), sizeId, quantity, isCustom: false,
+});
+check("fixed medium 119 kr → 11900", getItemUnitPriceOre(fixedLine(119, "medium")), 11900);
+check("fixed large 119×1.2 → round(142.8)=143 kr → 14300", getItemUnitPriceOre(fixedLine(119, "large")), 14300);
+check("fixed large ×3 → 42900", getItemLineTotalOre(fixedLine(119, "large", 3)), 42900);
+
+// ── Legacy: persisted customs without customPriceOre price as before ────
+const legacyLine = {
+  id: "m1-custom-old", meal: meal(119), sizeId: "medium", quantity: 1,
+  isCustom: true, ingredientSurchargeKr: 67,
+};
+check("legacy custom 119+67 kr → 18600 (historiskt oförändrat)", getItemUnitPriceOre(legacyLine), 18600);
+
+// ── Drinks: öre passthrough ─────────────────────────────────────────────
+const drinkLine = {
+  id: "drink-d1", kind: "drink", quantity: 2, sizeId: "medium", isCustom: false,
+  meal: meal(20), drink: { priceOre: 2000 },
+};
+check("drink 2000 öre × 2 → 4000", getItemLineTotalOre(drinkLine), 4000);
+
+// ── Wiring: the tested function is the one actually in use ──────────────
+const wiring = [
+  ["context/CartContext.tsx", "getItemLineTotalOre", "CartContext summerar inte via cartMath"],
+  ["features/cart/CartScreen.tsx", "getItemUnitPriceOre", "CartScreen prissätter inte raden via cartMath"],
+  ["features/menu/MealCard.tsx", "personalData.calc.totalPriceOre,", "MealCard skickar inte exakt öre till addItem"],
+  ["features/menu/MealDetailScreen.tsx", "personalData.calc.totalPriceOre,", "MealDetail skickar inte exakt öre till addItem"],
+  ["features/anpassar/NutriAnpassarScreen.tsx", "calcResult.totalPriceOre", "Anpassar skickar inte exakt öre till addItem"],
+  ["features/heldag/HeldagScreen.tsx", "r.calcResult.totalPriceOre", "Heldag skickar inte exakt öre till addItem"],
+];
+for (const [file, needle, message] of wiring) {
+  if (!readFileSync(file, "utf8").includes(needle)) failures.push(`${file}: ${message}`);
+}
+
+// ── Report ──────────────────────────────────────────────────────────────
+if (failures.length > 0) {
+  console.error("✗ Custom meal pricing guard failed:\n");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log("✓ Custom meal pricing preserves exact öre through the cart:");
+console.log("    18586 öre stays 18586 (never 18600); ×2 = 37172; sums are exact");
+console.log("    fixed meals and drinks keep their historical pricing");
+console.log("    legacy persisted customs keep the old surcharge formula");
+console.log("    CartContext/CartScreen price through cartMath; all four add-sites pass totalPriceOre");

--- a/scripts/check-ingredient-limits.mjs
+++ b/scripts/check-ingredient-limits.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Limit guard: the portion optimizer respects admin-set ingredient limits.
+ *
+ * WHY THIS EXISTS. Personal portions are bounded by Ingredient
+ * MinAmountG/MaxAmountG from the library; where those are NULL the optimizer
+ * falls back to 0/500 g. Realistic limits are DB data (admin-owned), so the
+ * code contract this guard pins is small but load-bearing:
+ *
+ *   1. an explicit MaxAmountG is never exceeded,
+ *   2. an explicit MinAmountG is never undercut,
+ *   3. NULL keeps the historical 0/500 fallback exactly,
+ *   4. two sizes that both saturate at max produce IDENTICAL portions —
+ *      which the M/L-equivalence rule then collapses into one choice,
+ *   5. fixed-role categories (Grönsaker/Såser/Toppings/Mejeri) never scale.
+ *
+ * Like the other guards, this transpiles the REAL optimizer and equivalence
+ * sources and asserts on the imported result.
+ *
+ * Run: npm run limits:check
+ */
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+
+const failures = [];
+const check = (name, ok) => { if (!ok) failures.push(name); };
+
+const outDir = mkdtempSync(join(tmpdir(), "nutri-limits-"));
+const transpile = (src, name) => {
+  const js = ts.transpileModule(readFileSync(src, "utf8"), {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 },
+  }).outputText;
+  const p = join(outDir, name);
+  writeFileSync(p, js);
+  return p;
+};
+const { optimizeIngredients } = await import(pathToFileURL(
+  transpile("features/anpassar/optimizer.ts", "optimizer.mjs")).href);
+const { areCustomMealPortionsEquivalent } = await import(pathToFileURL(
+  transpile("features/menu/portionEquivalence.ts", "portionEquivalence.mjs")).href);
+
+// ── Fixtures: a protein + a carb base + a fixed sauce ───────────────────
+const lib = (minMax) => [
+  { id: "prot", name: "Kyckling", category: "Protein",
+    proteinG100g: 31, carbsG100g: 0, fatG100g: 3.6, calories100g: 165,
+    minAmountG: minMax?.prot?.[0] ?? null, maxAmountG: minMax?.prot?.[1] ?? null },
+  { id: "carb", name: "Puré", category: "Baser",
+    proteinG100g: 1.5, carbsG100g: 22, fatG100g: 1.5, calories100g: 105,
+    minAmountG: minMax?.carb?.[0] ?? null, maxAmountG: minMax?.carb?.[1] ?? null },
+  { id: "sauce", name: "Chimichurri", category: "Såser",
+    proteinG100g: 1, carbsG100g: 4, fatG100g: 18, calories100g: 180,
+    minAmountG: null, maxAmountG: null },
+];
+const recipe = [
+  { ingredientId: "prot", name: "Kyckling", amountG: 155 },
+  { ingredientId: "carb", name: "Puré", amountG: 200 },
+  { ingredientId: "sauce", name: "Chimichurri", amountG: 30 },
+];
+const bigTarget = { label: "Lunch", calories: 1400, proteinG: 60, carbsG: 200, fatG: 30, timingPurpose: "" };
+const amounts = (res) => Object.fromEntries(res.map((i) => [i.ingredientId, i.amountG]));
+
+// ── 1–2. Explicit limits clamp ──────────────────────────────────────────
+const limited = amounts(optimizeIngredients(recipe, lib({ prot: [80, 250], carb: [100, 350] }), bigTarget));
+check(`MaxAmountG respekteras (kyckling ${limited.prot} ≤ 250)`, limited.prot <= 250);
+check(`MaxAmountG respekteras (puré ${limited.carb} ≤ 350)`, limited.carb <= 350);
+
+const tinyTarget = { label: "Mellanmål", calories: 120, proteinG: 5, carbsG: 10, fatG: 3, timingPurpose: "" };
+const minned = amounts(optimizeIngredients(recipe, lib({ prot: [80, 250], carb: [100, 350] }), tinyTarget));
+check(`MinAmountG respekteras (kyckling ${minned.prot} ≥ 80)`, minned.prot >= 80);
+check(`MinAmountG respekteras (puré ${minned.carb} ≥ 100)`, minned.carb >= 100);
+
+// ── 3. NULL = the historical 0/500 fallback, unchanged ──────────────────
+const fallback = amounts(optimizeIngredients(recipe, lib(null), bigTarget));
+check(`NULL-fallback tillåter > 250 (kyckling ${fallback.prot})`, fallback.prot > 250);
+check(`NULL-fallback stannar vid 500 (puré ${fallback.carb} ≤ 500)`, fallback.carb <= 500);
+
+// ── 4. Saturated M and L are identical → equivalence collapses them ─────
+const sat = { prot: [80, 200], carb: [100, 250] };
+const satM = optimizeIngredients(recipe, lib(sat), bigTarget);
+const satL = optimizeIngredients(recipe, lib(sat),
+  { ...bigTarget, calories: 1680, proteinG: 72, carbsG: 240, fatG: 36 });
+check("mättade M/L blir ekvivalenta → L döljs",
+  areCustomMealPortionsEquivalent({ ingredients: satM }, { ingredients: satL }));
+
+// ── 5. Fixed-role categories never scale ────────────────────────────────
+check(`fixed-roll skalas aldrig (chimichurri ${fallback.sauce} = 30)`, fallback.sauce === 30);
+check(`fixed-roll skalas aldrig med limits (${limited.sauce} = 30)`, limited.sauce === 30);
+
+// ── Rapport ─────────────────────────────────────────────────────────────
+if (failures.length > 0) {
+  console.error("✗ Ingredient limit guard failed:\n");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log("✓ The optimizer honours ingredient limits:");
+console.log("    explicit max/min clamp; NULL keeps the historical 0/500 fallback");
+console.log("    saturated M/L collapse to one choice via the equivalence rule");
+console.log("    fixed-role categories (sauces etc.) never scale");

--- a/scripts/check-portion-sizes.mjs
+++ b/scripts/check-portion-sizes.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Size guard: personal M/L are only offered as two choices when they are two
+ * portions, and the chosen size is what the cart carries.
+ *
+ * WHY THIS EXISTS. When every scalable ingredient saturates at MaxAmountG for
+ * M, the L optimization returns identical grams — same food, same macros,
+ * same price — and "L" would be a fake upgrade. And the personalized
+ * add-sites used to hardcode sizeId "medium", so a chosen L was stored and
+ * cooked as an M.
+ *
+ * Like pricing:check, this transpiles the REAL features/menu/
+ * portionEquivalence.ts with the project's TypeScript and asserts against the
+ * imported result, then asserts the wiring so the tested rule is provably the
+ * one the screens use.
+ *
+ * Run: npm run sizes:check
+ */
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+
+const failures = [];
+const check = (name, actual, expected) => {
+  if (actual !== expected) failures.push(`${name}: fick ${actual}, förväntade ${expected}`);
+};
+
+// ── Transpile the real module (its only import is type-only → erased) ───
+const outDir = mkdtempSync(join(tmpdir(), "nutri-sizes-"));
+const js = ts.transpileModule(readFileSync("features/menu/portionEquivalence.ts", "utf8"), {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 },
+}).outputText;
+const outPath = join(outDir, "portionEquivalence.mjs");
+writeFileSync(outPath, js);
+
+const { areCustomMealPortionsEquivalent, arePersonalSizesEquivalent } =
+  await import(pathToFileURL(outPath).href);
+
+const portion = (...ingredients) => ({
+  ingredients: ingredients.map(([ingredientId, amountG]) => ({ ingredientId, amountG })),
+});
+const ready = (p) => ({ status: "ready", data: p });
+
+// ── 1. Different grams → two real portions, both offered ────────────────
+check(
+  "olika gram → INTE ekvivalenta",
+  areCustomMealPortionsEquivalent(portion(["a", 200], ["b", 100]), portion(["a", 240], ["b", 120])),
+  false,
+);
+
+// ── 2. Identical grams → equivalent ─────────────────────────────────────
+check(
+  "identiska gram → ekvivalenta",
+  areCustomMealPortionsEquivalent(portion(["a", 200], ["b", 100]), portion(["a", 200], ["b", 100])),
+  true,
+);
+
+// ── 3. Same recipe, different array order → equivalent ──────────────────
+check(
+  "samma recept i annan ordning → ekvivalenta",
+  areCustomMealPortionsEquivalent(portion(["a", 200], ["b", 100]), portion(["b", 100], ["a", 200])),
+  true,
+);
+
+// ── 4. Same totals, different distribution → NOT equivalent ─────────────
+// Both weigh 300 g (and could carry the same floor price) — but they are
+// different recipes, so both sizes must stay offered.
+check(
+  "samma totalvikt men olika fördelning → INTE ekvivalenta",
+  areCustomMealPortionsEquivalent(portion(["a", 200], ["b", 100]), portion(["a", 100], ["b", 200])),
+  false,
+);
+
+// Different ingredient sets, same count.
+check(
+  "olika ingrediens-id → INTE ekvivalenta",
+  areCustomMealPortionsEquivalent(portion(["a", 200]), portion(["c", 200])),
+  false,
+);
+
+// Subset/superset.
+check(
+  "delmängd → INTE ekvivalenta",
+  areCustomMealPortionsEquivalent(portion(["a", 200], ["b", 100]), portion(["a", 200])),
+  false,
+);
+
+// ── Screen-level rule: only CONFIRMED equivalence hides anything ────────
+const p = portion(["a", 200], ["b", 100]);
+check("båda ready + identiska → true", arePersonalSizesEquivalent(ready(p), ready(p)), true);
+check("ena laddar → ALDRIG dolt på gissning", arePersonalSizesEquivalent(ready(p), { status: "loading" }), false);
+check("off/off (icke-personaliserad) → false", arePersonalSizesEquivalent({ status: "off" }, { status: "off" }), false);
+check("error → false", arePersonalSizesEquivalent(ready(p), { status: "error" }), false);
+
+// ── Wiring: the rule and the size actually reach the screens ────────────
+const wiring = [
+  // Both screens use the ONE shared rule (no duplicated identity logic).
+  ["features/menu/MealCard.tsx", "arePersonalSizesEquivalent(personalMedium, personalLarge)", "MealCard använder inte den delade regeln"],
+  ["features/menu/MealDetailScreen.tsx", "arePersonalSizesEquivalent(personalMedium, personalLarge)", "MealDetail använder inte den delade regeln"],
+  // L filtered only on confirmed equivalence.
+  ["features/menu/MealCard.tsx", 'sizesEquivalent && s.id === "large"', "MealCard döljer inte L vid identitet"],
+  ["features/menu/MealDetailScreen.tsx", 'sizesEquivalent && s.id === "large"', "MealDetail döljer inte L vid identitet"],
+  // Safe fallback L→M when equivalence lands while L is selected.
+  ["features/menu/MealCard.tsx", 'sizesEquivalent && selectedSize === "large") setSelectedSize("medium")', "MealCard saknar säker L→M-fallback"],
+  ["features/menu/MealDetailScreen.tsx", 'sizesEquivalent && selectedSize === "large") setSelectedSize("medium")', "MealDetail saknar säker L→M-fallback"],
+  // Add pauses while the selected personal size loads.
+  ["features/menu/MealCard.tsx", "personalAddPending", "MealCard spärrar inte Add under personlig laddning"],
+  ["features/menu/MealDetailScreen.tsx", "personalAddPending", "MealDetail spärrar inte Add under personlig laddning"],
+  // The chosen size — not a hardcoded "medium" — goes into the cart.
+  ["features/menu/MealCard.tsx", "effectiveSize,\n        1,", "MealCard skickar inte vald size till addItem"],
+  ["features/menu/MealDetailScreen.tsx", "effectiveSize,\n        quantity,", "MealDetail skickar inte vald size till addItem"],
+];
+for (const [file, needle, message] of wiring) {
+  if (!readFileSync(file, "utf8").replaceAll("\r\n", "\n").includes(needle)) {
+    failures.push(`${file}: ${message}`);
+  }
+}
+
+// The screens without an M/L choice stay semantically medium — documented,
+// not accidental.
+for (const file of ["features/anpassar/NutriAnpassarScreen.tsx", "features/heldag/HeldagScreen.tsx"]) {
+  const src = readFileSync(file, "utf8");
+  if (!src.includes('"medium"')) failures.push(`${file}: förlorade sin medium-semantik`);
+  if (!src.includes("Semantically correct")) failures.push(`${file}: medium-valet är odokumenterat`);
+}
+
+// ── Report ──────────────────────────────────────────────────────────────
+if (failures.length > 0) {
+  console.error("✗ Portion size guard failed:\n");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log("✓ Personal M/L behave as real portions:");
+console.log("    identical grams (any order) → equivalent; different grams/distribution → not");
+console.log("    equal totals alone never equate portions; loading/error never hides an option");
+console.log("    both screens share one rule, hide L on confirmed identity, and fall back L→M safely");
+console.log("    the chosen size reaches the cart; Anpassar/Heldag stay documented medium");

--- a/types/cart.ts
+++ b/types/cart.ts
@@ -71,6 +71,26 @@ export interface CartItem {
   };
   customIngredients?: { ingredientId: string; name: string; amountG: number }[];
   ingredientSurchargeKr?: number;
+  /**
+   * The EXACT backend price for a custom/personalized line, in öre, straight
+   * from /api/custom-meal/calculate's totalPriceOre.
+   *
+   * WHY THIS EXISTS. The cart used to reconstruct a custom line's price as
+   * basePrice + ingredientSurchargeKr, where the surcharge had been rounded
+   * to whole kronor — so a server price of 18586 öre displayed and summed as
+   * 18600, and the cart total could differ from what the backend charges at
+   * order time. Every money computation for a custom line must use this
+   * field when present; ingredientSurchargeKr remains only so carts
+   * persisted before this field existed keep pricing exactly as they did.
+   *
+   * Display/summation only: the order payload still carries no price, and
+   * the backend recomputes from ingredient grams regardless.
+   *
+   * Mobile-only addition to the shared cart shape for now — the web cart has
+   * the same rounding flaw and needs the same field; until it gets it, this
+   * optional field is ignored by any web-parity tooling.
+   */
+  customPriceOre?: number;
   containerTypeId?: string;
   /** Frontend-only meal-slot tag for Heldag flows. Not sent to backend in V1. */
   slot?: MealSlot;

--- a/utils/cartMath.ts
+++ b/utils/cartMath.ts
@@ -1,5 +1,5 @@
 import type { CartItem } from "@/types/cart";
-import { MEAL_SIZES } from "@/utils/pricing";
+import { MEAL_SIZES, previewMealPriceOre } from "@/utils/pricing";
 
 /**
  * Per-item cart math, ported from the helpers in Nutri-Frontend's
@@ -57,4 +57,53 @@ export function getItemWeightG(item: CartItem): number {
   const mult = size?.macroMultiplier ?? 1;
   const baseGrams = item.meal.ingredients.reduce((sum, ing) => sum + (ing.amountG ?? 0), 0);
   return Math.round(baseGrams * mult) * item.quantity;
+}
+
+/**
+ * The unit price of a cart line, in öre — THE single pricing authority for
+ * cart display and summation. CartContext's totals and CartScreen's line
+ * rendering both call this, so a price can never differ between the row and
+ * the summary.
+ *
+ * WHY IT EXISTS. The same formula used to live in two places, and for
+ * custom/personalized lines both reconstructed the price from a
+ * whole-kronor surcharge — so the server's öre-precise 18586 became 18600 on
+ * screen and in the total. Rules, in order:
+ *
+ *  - drink lines: the drink's own öre price, unchanged;
+ *  - custom lines that carry customPriceOre: EXACTLY that number — this is
+ *    the backend's /custom-meal/calculate result and the whole point;
+ *  - legacy custom/surcharge lines (persisted carts from before
+ *    customPriceOre existed): the historical basePrice×multiplier+surcharge
+ *    formula, unchanged so an old stored cart prices as it always did;
+ *  - fixed meals: the backend's whole-SEK rounding via previewMealPriceOre,
+ *    unchanged.
+ *
+ * The order payload still carries no price and the backend recomputes from
+ * ingredient grams — this is honest display, not price authority.
+ */
+export function getItemUnitPriceOre(item: CartItem): number {
+  if (item.kind === "drink" && item.drink) {
+    return item.drink.priceOre;
+  }
+
+  if (item.isCustom && item.customPriceOre !== undefined) {
+    return item.customPriceOre;
+  }
+
+  const size = MEAL_SIZES.find((s) => s.id === item.sizeId);
+  const multiplier = size?.priceMultiplier ?? 1;
+  const surcharge = item.ingredientSurchargeKr ?? 0;
+
+  if (!item.isCustom && surcharge === 0) {
+    return previewMealPriceOre(item.meal.basePrice, multiplier);
+  }
+
+  // Legacy path — kronor float, rounded to öre exactly as krToOre always did.
+  return Math.round((item.meal.basePrice * multiplier + surcharge) * 100);
+}
+
+/** Line total in öre: integer unit price × integer quantity — no float leg. */
+export function getItemLineTotalOre(item: CartItem): number {
+  return getItemUnitPriceOre(item) * item.quantity;
 }


### PR DESCRIPTION
Production-ready personalized portion fixes, verified end-to-end against the deployed backend.

* preserve the exact backend custom meal price through the cart in ore (no float rounding drift)
* hide Large when personalized M/L resolve to identical ingredient grams
* preserve the actual selected medium/large size through addItem -> order payload
* prevent static fallback add while the personalized calculation is loading
* keep fixed/non-personalized meals and drinks priced exactly as before
* add regression guards: pricing (pricing:check), size equivalence (sizes:check), ingredient limits (limits:check)
* production backend/data rollout already verified live: Min/Max enforcement, 12/12 boundary tests, CSB/BPB regressions exact
* no Swish/payment integration changes (swish:check green)

Verification: typecheck, lint, i18n:check (1127 keys), pricing:check, sizes:check, limits:check, swish:check - all green.