### PR TITLE
fix(dayplan): order actions, one plan entry, and one set of slot targets

### DIFF
--- a/features/dayplan/DayPlanSlotList.tsx
+++ b/features/dayplan/DayPlanSlotList.tsx
@@ -30,7 +30,17 @@ export function DayPlanSlotList({
   slotAccessibilityHint,
 }: {
   mealTab: "3" | "4";
-  onMealTabChange: (tab: "3" | "4") => void;
+  /**
+   * Omitted = the count is not changeable here, and the pills are not shown.
+   *
+   * Home does that deliberately. The toggle only ever changed what Home
+   * DISPLAYED — it wrote nothing — so switching it moved Home's numbers away
+   * from the saved plan while the menu, which reads that plan, kept
+   * recommending against the stored one. A control that silently creates two
+   * sets of numbers for the same slot is worse than no control; the meal
+   * count is changed in the planner, where it is saved.
+   */
+  onMealTabChange?: (tab: "3" | "4") => void;
   slots: ApiMealDistribution[];
   onSlotPress?: (slot: ApiMealDistribution) => void;
   renderAction?: (slot: ApiMealDistribution) => ReactNode;
@@ -41,22 +51,24 @@ export function DayPlanSlotList({
 
   return (
     <>
-      <View style={styles.tabRow}>
-        {(["3", "4"] as const).map((tab) => (
-          <Pressable
-            key={tab}
-            onPress={() => onMealTabChange(tab)}
-            style={[styles.tab, mealTab === tab && styles.tabActive]}
-            accessibilityRole="button"
-            accessibilityState={{ selected: mealTab === tab }}
-            accessibilityLabel={t("planDay.mealCount", { count: Number(tab) })}
-          >
-            <ThemedText style={[styles.tabText, mealTab === tab && styles.tabTextActive]}>
-              {t("planDay.mealCount", { count: Number(tab) })}
-            </ThemedText>
-          </Pressable>
-        ))}
-      </View>
+      {onMealTabChange ? (
+        <View style={styles.tabRow}>
+          {(["3", "4"] as const).map((tab) => (
+            <Pressable
+              key={tab}
+              onPress={() => onMealTabChange(tab)}
+              style={[styles.tab, mealTab === tab && styles.tabActive]}
+              accessibilityRole="button"
+              accessibilityState={{ selected: mealTab === tab }}
+              accessibilityLabel={t("planDay.mealCount", { count: Number(tab) })}
+            >
+              <ThemedText style={[styles.tabText, mealTab === tab && styles.tabTextActive]}>
+                {t("planDay.mealCount", { count: Number(tab) })}
+              </ThemedText>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
 
       <View style={styles.slotList}>
         {slots.map((slot, i) => {

--- a/features/dayplan/dayPlanNavigation.ts
+++ b/features/dayplan/dayPlanNavigation.ts
@@ -1,0 +1,45 @@
+import { categoryForSlot } from "@/features/menu/mealRecommendation";
+import type { WizardSlot } from "@/features/anpassar/optimizer";
+
+/**
+ * WHERE A DAY-PLAN ROW CAN TAKE YOU. One definition, used by every caller.
+ *
+ * The row itself and its "Beställ" button do the SAME thing, and they do it
+ * by calling the same function — because two places that navigate "to the
+ * menu for this slot" will otherwise drift the first time either is touched,
+ * and the way they drift is silent: Middag quietly served lunch portions.
+ */
+
+/** The planner, for the whole day rather than one slot. */
+export const PLAN_DAY_ROUTE = "/planera-dagen" as const;
+
+export interface MenuSlotTarget {
+  pathname: "/(tabs)/meny";
+  params: { category: string; slot: WizardSlot; navKey: string };
+}
+
+/**
+ * The menu, opened on the category this slot belongs to and carrying the
+ * slot itself.
+ *
+ * THE SLOT IS NOT REDUNDANT. Lunch and Middag share the Huvudmåltider chip —
+ * the menu has no lunch tab and no dinner tab — so without it a tap on
+ * Middag at 12:00 would be served lunch portions by the menu's clock rule,
+ * and the M/L recommendation would be computed against the wrong target.
+ *
+ * `navKey` distinguishes two taps on the same slot. The menu applies an
+ * incoming category through an effect keyed on the params, so without a
+ * changing value a second tap is the same two params and the effect never
+ * re-runs — leaving a chip the customer switched by hand in between, and a
+ * tap that looks dead.
+ */
+export function menuHrefForSlot(slot: WizardSlot, now: number): MenuSlotTarget {
+  return {
+    pathname: "/(tabs)/meny",
+    params: {
+      category: categoryForSlot(slot),
+      slot,
+      navKey: String(now),
+    },
+  };
+}

--- a/features/dayplan/dayPlanSlots.ts
+++ b/features/dayplan/dayPlanSlots.ts
@@ -31,6 +31,45 @@ export function orderForDisplay(meals: ApiMealDistribution[]): ApiMealDistributi
   return [...meals].sort((a, b) => (DISPLAY_ORDER[a.label] ?? 99) - (DISPLAY_ORDER[b.label] ?? 99));
 }
 
+/**
+ * The saved plan as the customer is SHOWN it — the single derivation Home,
+ * the planner and the menu all read.
+ *
+ * ── WHY THIS EXISTS ──────────────────────────────────────────────────
+ *
+ * Home renders `visibleSlotsFor(tab, meals)`. The menu used to read the
+ * STORED rows straight off the saved plan. In 4-meal mode those agree, so it
+ * looked fine. In 3-MEAL MODE they do not: the snack is dropped and its
+ * calories are scaled back into the three main meals, which on a 2000 kcal
+ * plan puts Lunch 150 kcal apart between the two screens — and the menu then
+ * recommended M or L against a target the customer had never been shown.
+ *
+ * The meal count comes from the PLAN, not from whatever tab a screen
+ * happens to be showing, so every reader derives the same numbers without
+ * having to know about each other.
+ *
+ * Pure, and deliberately free of the app graph, so the guard can exercise
+ * the real rule rather than a copy of it.
+ */
+export interface SavedPlanShape {
+  mealCount?: number;
+  meals?: { label: string; calories: number; proteinG: number; carbsG: number; fatG: number }[];
+}
+
+export function savedPlanTargets(plan: SavedPlanShape | null | undefined): ApiMealDistribution[] {
+  const meals = plan?.meals ?? [];
+  if (meals.length === 0) return [];
+  const stored: ApiMealDistribution[] = meals.map((m) => ({
+    label: m.label,
+    calories: m.calories,
+    proteinG: m.proteinG,
+    carbsG: m.carbsG,
+    fatG: m.fatG,
+    timingPurpose: "",
+  }));
+  return visibleSlotsFor(plan?.mealCount === 3 ? "3" : "4", stored);
+}
+
 /** The slot editor's working copy — never the plan itself. */
 export interface SlotDraft {
   calories: number;

--- a/features/home/HomeDayPlan.tsx
+++ b/features/home/HomeDayPlan.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import { useRouter } from "expo-router";
+import { CalendarRange } from "lucide-react-native";
 
 import { ThemedText } from "@/components/ui/ThemedText";
 import { DayPlanSlotList } from "@/features/dayplan/DayPlanSlotList";
-import { visibleSlotsFor } from "@/features/dayplan/dayPlanSlots";
-import { categoryForSlot, parseSlot } from "@/features/menu/mealRecommendation";
+import { savedPlanTargets, visibleSlotsFor } from "@/features/dayplan/dayPlanSlots";
+import { menuHrefForSlot, PLAN_DAY_ROUTE } from "@/features/dayplan/dayPlanNavigation";
+import { parseSlot } from "@/features/menu/mealRecommendation";
 import { useTodayDayPlanQuery, useTodayNutritionQuery } from "@/services/api/nutritionQueries";
 import { useTranslation } from "@/i18n";
 import { colors, fontFamily, radius, spacing } from "@/theme";
@@ -40,34 +42,43 @@ export function HomeDayPlan() {
   const baseMeals = useMemo(() => todayQuery.data?.meals ?? [], [todayQuery.data]);
   const saved = dayPlanQuery.data;
 
-  // The saved server plan wins over the backend baseline — the planner's
-  // rule, so Home and the planner never disagree about today.
-  const meals = useMemo(() => {
-    if (saved && saved.meals.length > 0) {
-      return saved.meals.map((m) => ({
-        label: m.label,
-        calories: m.calories,
-        proteinG: m.proteinG,
-        carbsG: m.carbsG,
-        fatG: m.fatG,
+  /**
+   * The numbers on these rows are the SAVED PLAN's, derived exactly the way
+   * the menu derives the targets it recommends against — one function,
+   * `savedPlanTargets`, reading the plan's own meal count.
+   *
+   * Home no longer keeps a 3/4 toggle of its own. It only ever changed what
+   * Home displayed (it wrote nothing), so switching it moved these numbers
+   * away from the plan while the menu kept recommending against the stored
+   * one — the same slot showing two different sets of numbers. The meal
+   * count is changed in the planner, where it is saved and where every
+   * reader picks it up.
+   */
+  const mealTab: "3" | "4" = saved?.mealCount === 3 ? "3" : "4";
+
+  const visibleSlots = useMemo(() => {
+    const fromPlan = savedPlanTargets(saved);
+    if (fromPlan.length > 0) {
+      // Carry the timing copy across from the backend baseline; the saved
+      // plan does not store it.
+      return fromPlan.map((m) => ({
+        ...m,
         timingPurpose: baseMeals.find((bm) => bm.label === m.label)?.timingPurpose ?? "",
       }));
     }
-    return baseMeals;
+    // No saved plan yet — the backend's automatic distribution, shown as-is.
+    return visibleSlotsFor("4", baseMeals);
   }, [saved, baseMeals]);
 
-  // Hydrated from the saved plan once it arrives, then owned by the user's
-  // taps. `hydrated` (rather than comparing values) is what keeps a later
-  // refetch from yanking the toggle back under a finger.
-  const [mealTab, setMealTab] = useState<"3" | "4">("4");
-  const [hydrated, setHydrated] = useState(false);
-  useEffect(() => {
-    if (hydrated || !dayPlanQuery.isFetched) return;
-    if (saved && saved.meals.length > 0) setMealTab(saved.mealCount === 3 ? "3" : "4");
-    setHydrated(true);
-  }, [hydrated, dayPlanQuery.isFetched, saved]);
-
-  const visibleSlots = useMemo(() => visibleSlotsFor(mealTab, meals), [mealTab, meals]);
+  /** The one navigation the row and its Beställ button share. */
+  const openMenuForSlot = useCallback(
+    (label: string) => {
+      const wizardSlot = parseSlot(label);
+      if (!wizardSlot) return;
+      router.navigate(menuHrefForSlot(wizardSlot, Date.now()));
+    },
+    [router]
+  );
 
   if (visibleSlots.length === 0) return null;
 
@@ -75,68 +86,74 @@ export function HomeDayPlan() {
     <View style={{ gap: spacing[2] }}>
       <DayPlanSlotList
         mealTab={mealTab}
-        onMealTabChange={setMealTab}
         slots={visibleSlots}
         slotAccessibilityHint={t("home.dayPlanSlotHint")}
-        onSlotPress={(slot) => {
-          // Straight into the menu with that category selected — no
-          // intermediate screen. The SLOT rides along because Lunch and
-          // Middag share the Huvudmåltider chip, and it is the slot (not the
-          // chip) that decides the recommended portion.
-          const wizardSlot = parseSlot(slot.label);
-          if (!wizardSlot) return;
-          router.navigate({
-            pathname: "/(tabs)/meny",
-            params: {
-              category: categoryForSlot(wizardSlot),
-              slot: wizardSlot,
-              // The menu applies an incoming category through an effect keyed
-              // on the params. Tapping the SAME slot twice is the same two
-              // params, so without a changing third the effect would not run
-              // again and a chip switched by hand in between would stand —
-              // the tap would look dead. The menu already reads this; nothing
-              // used to send it.
-              navKey: String(Date.now()),
-            },
-          });
-        }}
-        // THE EDIT AFFORDANCE, restored. The planner's rows have carried an
-        // "Ändra" button since patch 12; Home's rows were given a decorative
-        // chevron instead and the only door to the planner (the menu's
-        // "Planera din dag" card) was removed in the same change, which left
-        // every slot un-editable. Same control, same copy, same look as the
-        // planner — and it carries the slot, so Lunch and Middag open their
-        // own row rather than whichever the clock would have guessed.
+        onSlotPress={(slot) => openMenuForSlot(slot.label)}
+        // ORDER, NOT EDIT. These four buttons used to open the planner on
+        // their own slot — four separate doors to the same screen. Editing
+        // the plan is now one shared entry below the list; what a row offers
+        // is the thing you actually came to Home to do, which is order the
+        // meal it describes.
+        //
+        // Same destination as the row press, through the same helper, so the
+        // two can never drift apart.
         renderAction={(slot) => {
           const wizardSlot = parseSlot(slot.label);
           if (!wizardSlot) return null;
           const label = t(`planDay.slots.${slot.label}`, { defaultValue: slot.label });
           return (
             <Pressable
-              onPress={() =>
-                router.push({ pathname: "/planera-dagen", params: { slot: wizardSlot } })
-              }
-              style={({ pressed }) => [styles.editBtn, pressed && { opacity: 0.7 }]}
+              onPress={() => openMenuForSlot(slot.label)}
+              style={({ pressed }) => [styles.orderBtn, pressed && { opacity: 0.7 }]}
               accessibilityRole="button"
-              accessibilityLabel={t("planDay.editSlotAria", { slot: label })}
+              accessibilityLabel={`${t("planDay.order")} — ${label}`}
             >
-              <ThemedText style={styles.editBtnText}>{t("planDay.edit")}</ThemedText>
+              <ThemedText style={styles.orderBtnText}>{t("planDay.order")}</ThemedText>
             </Pressable>
           );
         }}
       />
+
+      {/* ONE way into the planner, for the whole day. The four per-slot
+          buttons that used to lead here are gone: the planner shows all four
+          slots anyway, so four doors into the same room was three too many —
+          and it left the rows with no way to do the obvious thing. */}
+      <Pressable
+        onPress={() => router.push(PLAN_DAY_ROUTE)}
+        style={({ pressed }) => [styles.planCta, pressed && { opacity: 0.8 }]}
+        accessibilityRole="button"
+        accessibilityLabel={t("planDay.title")}
+      >
+        <CalendarRange size={14} color={colors.accent} strokeWidth={2} />
+        <ThemedText style={styles.planCtaText}>{t("planDay.title")}</ThemedText>
+      </Pressable>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  editBtn: {
+  // Same shape the planner's row control has always had — this replaces
+  // "Ändra" in place rather than introducing a new visual language.
+  orderBtn: {
     borderRadius: radius.btn,
     borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: "rgba(255,255,255,0.06)",
+    borderColor: colors.accentBorder,
+    backgroundColor: colors.accentSoft,
     paddingHorizontal: spacing[3],
     paddingVertical: spacing[2],
   },
-  editBtnText: { fontSize: 12, fontFamily: fontFamily.bodySemibold, color: colors.textPrimary },
+  orderBtnText: { fontSize: 12, fontFamily: fontFamily.bodySemibold, color: colors.accent },
+  planCta: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing[2],
+    marginTop: spacing[1],
+    borderRadius: radius.btn,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: "rgba(255,255,255,0.04)",
+    paddingVertical: spacing[3],
+  },
+  planCtaText: { fontSize: 13, fontFamily: fontFamily.bodySemibold, color: colors.textPrimary },
 });

--- a/features/menu/MenuScreen.tsx
+++ b/features/menu/MenuScreen.tsx
@@ -22,6 +22,7 @@ import { colors, fontFamily, radius, spacing } from "@/theme";
 import { MealCard } from "./MealCard";
 import { DrinkCard } from "./DrinkCard";
 import { PersonalMenuSection } from "./PersonalMenuSection";
+import { SlotTargetBanner } from "./SlotTargetBanner";
 import { GoWellFlavorCarousel } from "./GoWellFlavorCarousel";
 import {
   categoryForSlot,
@@ -332,6 +333,15 @@ export function MenuScreen() {
                     standard cards in the list below. */}
                 {activeId === "dryck" && goWellDrinks.length > 0 ? (
                   <GoWellFlavorCarousel drinks={goWellDrinks} />
+                ) : null}
+                {/* The slot's TARGET — shown only when the menu was opened
+                    from a day-plan row, and only for the slot that row
+                    named. The menu already knew this number (it is what
+                    picks M or L); it just never showed it, so the customer
+                    had nothing to compare Home against except a meal card,
+                    which is a different quantity entirely. */}
+                {activeSlot && requestedSlot === activeSlot ? (
+                  <SlotTargetBanner slot={activeSlot} target={activeSlotTarget} />
                 ) : null}
                 <ThemedText style={styles.sectionLabel}>
                   {t(`menu.categories.${activeId}`).toUpperCase()} ·{" "}

--- a/features/menu/SlotTargetBanner.tsx
+++ b/features/menu/SlotTargetBanner.tsx
@@ -1,0 +1,83 @@
+import { StyleSheet, View } from "react-native";
+import { Target } from "lucide-react-native";
+
+import { ThemedText } from "@/components/ui/ThemedText";
+import type { ApiMealDistribution } from "@/services/api/nutrition";
+import type { WizardSlot } from "@/features/anpassar/optimizer";
+import { useTranslation } from "@/i18n";
+import { colors, fontFamily, radius, spacing } from "@/theme";
+
+/**
+ * The slot's TARGET, shown in the menu when it was opened from a day-plan row.
+ *
+ * ── WHY THIS EXISTS ──────────────────────────────────────────────────
+ *
+ * The menu already knew the target — it is what picks M or L — but it never
+ * SHOWED it. So the customer read "Lunch 750 kcal" on Home, opened the menu,
+ * saw a Chicken Bowl at 565 kcal, and reasonably concluded the two screens
+ * disagreed. They never did about the target; the target simply was not on
+ * screen to compare against.
+ *
+ * ── TWO NUMBERS, SAID OUT LOUD ───────────────────────────────────────
+ *
+ * This banner is the TARGET: what the plan says this slot should be.
+ * A meal card is that MEAL's own nutrition at the selected size — the
+ * numbers the cart will carry. They are different quantities and both are
+ * true, so the note underneath says which is which rather than leaving the
+ * customer to guess. Nothing here rounds, scales or recomputes: it renders
+ * the exact object `slotTarget` returns, which is the exact object Home
+ * renders from.
+ */
+export function SlotTargetBanner({
+  slot,
+  target,
+}: {
+  slot: WizardSlot;
+  /** Null while loading, or when there is no profile to plan from. */
+  target: ApiMealDistribution | null;
+}) {
+  const { t } = useTranslation();
+
+  // No target means no honest number to show — say nothing rather than a 0.
+  if (!target || target.calories <= 0) return null;
+
+  const slotName = t(`planDay.slots.${slot}`, { defaultValue: slot });
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.head}>
+        <Target size={13} color={colors.accent} strokeWidth={2.25} />
+        <ThemedText style={styles.headText}>
+          {slotName} · {t("menu.slotTarget.label")}
+        </ThemedText>
+      </View>
+      <ThemedText style={styles.values}>
+        {target.calories} kcal · {target.proteinG}g {t("home.macroProtein").toLowerCase()} ·{" "}
+        {target.carbsG}g {t("menu.carbsShort")} · {target.fatG}g {t("menu.fatShort")}
+      </ThemedText>
+      <ThemedText style={styles.note}>{t("menu.slotTarget.mealNote")}</ThemedText>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: 4,
+    borderRadius: radius.btn,
+    borderWidth: 1,
+    borderColor: colors.accentBorder,
+    backgroundColor: colors.accentSoft,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+  },
+  head: { flexDirection: "row", alignItems: "center", gap: 6 },
+  headText: {
+    fontSize: 11,
+    fontFamily: fontFamily.bodySemibold,
+    letterSpacing: 0.8,
+    color: colors.accent,
+    textTransform: "uppercase",
+  },
+  values: { fontSize: 13, fontFamily: fontFamily.bodyMedium, color: colors.textPrimary },
+  note: { fontSize: 11.5, lineHeight: 15, color: colors.textTertiary },
+});

--- a/features/menu/mealRecommendation.ts
+++ b/features/menu/mealRecommendation.ts
@@ -9,6 +9,7 @@ import {
   matchSlotLabel,
 } from "@/features/heldag/heldagBuilder";
 import type { WizardSlot } from "@/features/anpassar/optimizer";
+import { savedPlanTargets } from "@/features/dayplan/dayPlanSlots";
 
 /**
  * Personal portion recommendation for menu cards (patch 12).
@@ -106,19 +107,19 @@ export function slotTarget(
 ): ApiMealDistribution | null {
   // 1. Saved plan wins — it is the server-persisted, possibly manually
   //    edited plan the day planner wrote (and Nutri Anpassar reads).
-  const savedSlot = savedPlan?.meals?.find(
-    (m) => m.calories > 0 && matchSlotLabel(slot, m.label)
-  );
-  if (savedSlot) {
-    return {
-      label: savedSlot.label,
-      calories: savedSlot.calories,
-      proteinG: savedSlot.proteinG,
-      carbsG: savedSlot.carbsG,
-      fatG: savedSlot.fatG,
-      timingPurpose: "",
-    };
-  }
+  //
+  //    ── THE SAME NUMBERS HOME SHOWS ──────────────────────────────────
+  //    Read through visibleSlotsFor, which is what Home and the planner
+  //    render from. It matters in 3-MEAL MODE: there the snack is dropped
+  //    and its calories are scaled back into the three main meals, so the
+  //    STORED row and the DISPLAYED row are deliberately different numbers.
+  //    This function used to return the stored row while Home displayed the
+  //    scaled one — 150 kcal apart on Lunch for a 2000 kcal plan — so the
+  //    menu recommended a size against a target the customer had never been
+  //    shown. One transformation, one set of numbers.
+  const visible = savedPlanTargets(savedPlan);
+  const savedSlot = visible.find((m) => m.calories > 0 && matchSlotLabel(slot, m.label));
+  if (savedSlot) return savedSlot;
 
   // 2–3. Automatic distribution, then fallback share.
   if (!today) return null;

--- a/features/profile/ProfileScreen.tsx
+++ b/features/profile/ProfileScreen.tsx
@@ -3,7 +3,7 @@ import { Alert, Modal, Pressable, ScrollView, StyleSheet, Switch, View } from "r
 import { useRouter } from "expo-router";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronRight, Globe } from "lucide-react-native";
+import { CalendarRange, ChevronRight, Globe } from "lucide-react-native";
 
 import { ThemedText } from "@/components/ui/ThemedText";
 import { LoadingIndicator } from "@/components/feedback/LoadingIndicator";
@@ -48,6 +48,7 @@ import { colors, fontFamily, spacing } from "@/theme";
 import {
   deriveTrainingSessionsFromWeeklySchedule,
 } from "./profileOptions";
+import { PLAN_DAY_ROUTE } from "@/features/dayplan/dayPlanNavigation";
 import { EditSectionModal, type EditSection } from "./EditSectionModal";
 import {
   formFromProfile,
@@ -921,6 +922,29 @@ export function ProfileScreen() {
         </View>
       ) : null}
 
+      {/* ── 2b. PLANERA DIN DAG — part of the plan tool, not a settings row.
+          Sits directly under the active plan because that is what it acts
+          on: the plan above is the day's GOAL, this is how the day is spread
+          across Frukost / Mellanmål / Lunch / Middag. Same route constant
+          Home's CTA uses, so there is one way in and it cannot drift. ── */}
+      {np ? (
+        <Pressable
+          onPress={() => router.push(PLAN_DAY_ROUTE)}
+          style={({ pressed }) => [styles.planDayCard, pressed && { opacity: 0.85 }]}
+          accessibilityRole="button"
+          accessibilityLabel={t("profile.planDay")}
+        >
+          <View style={styles.planDayIcon}>
+            <CalendarRange size={16} color={colors.accent} strokeWidth={2} />
+          </View>
+          <View style={{ flex: 1, minWidth: 0 }}>
+            <ThemedText style={styles.planDayTitle}>{t("profile.planDay")}</ThemedText>
+            <ThemedText style={styles.planDaySub}>{t("profile.planDaySub")}</ThemedText>
+          </View>
+          <ChevronRight size={14} color="rgba(255,255,255,0.3)" />
+        </Pressable>
+      ) : null}
+
       {/* ── 3. MITT KONTO — moved directly under the active plan (release
           QA): the account basics are what the customer comes here to change,
           so they must not sit below the navigation rows. Release P13: ONE
@@ -1312,6 +1336,30 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     overflow: "hidden",
   },
+  // Same surface as planCard above it — this belongs to the plan section,
+  // not to the account rows further down.
+  planDayCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing[3],
+    marginTop: spacing[3],
+    backgroundColor: "#17171A",
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 16,
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[4],
+  },
+  planDayIcon: {
+    width: 34,
+    height: 34,
+    borderRadius: 12,
+    backgroundColor: colors.accentSoft,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  planDayTitle: { fontSize: 14, fontFamily: fontFamily.bodySemibold, color: colors.textPrimary },
+  planDaySub: { marginTop: 2, fontSize: 12, color: colors.textTertiary },
   planTop: {
     flexDirection: "row",
     alignItems: "flex-start",

--- a/i18n/locales/da.json
+++ b/i18n/locales/da.json
@@ -174,6 +174,7 @@
       "Mellanmål": "Mellemmåltid"
     },
     "edit": "Redigér",
+    "order": "Bestil",
     "editSlotAria": "Redigér {{slot}}",
     "summaryHead": "Din plan",
     "goalRow": "Målsum",

--- a/i18n/locales/da.json
+++ b/i18n/locales/da.json
@@ -160,6 +160,10 @@
       "explanation": "Baseret på dit mål og dagens plan.",
       "deviates": "Afviger fra din anbefaling ({{size}}).",
       "cta": "Vælg anbefalet"
+    },
+    "slotTarget": {
+      "label": "Dit mål",
+      "mealNote": "Tallene på hver ret nedenfor er rettens egen ernæring."
     }
   },
   "planDay": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -160,6 +160,10 @@
       "explanation": "Based on your goal and today's plan.",
       "deviates": "Differs from your recommendation ({{size}}).",
       "cta": "Choose recommended"
+    },
+    "slotTarget": {
+      "label": "Your target",
+      "mealNote": "The numbers on each meal below are that meal’s own nutrition."
     }
   },
   "planDay": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -174,6 +174,7 @@
       "Mellanmål": "Snack"
     },
     "edit": "Edit",
+    "order": "Order",
     "editSlotAria": "Edit {{slot}}",
     "summaryHead": "Your plan",
     "goalRow": "Goal total",

--- a/i18n/locales/sv.json
+++ b/i18n/locales/sv.json
@@ -160,6 +160,10 @@
       "explanation": "Baserat på ditt mål och dagens plan.",
       "deviates": "Avviker från din rekommendation ({{size}}).",
       "cta": "Välj rekommenderad"
+    },
+    "slotTarget": {
+      "label": "Ditt mål",
+      "mealNote": "Siffrorna på varje måltid nedan är måltidens egen näring."
     }
   },
   "planDay": {

--- a/i18n/locales/sv.json
+++ b/i18n/locales/sv.json
@@ -174,6 +174,7 @@
       "Mellanmål": "Mellanmål"
     },
     "edit": "Ändra",
+    "order": "Beställ",
     "editSlotAria": "Ändra {{slot}}",
     "summaryHead": "Din plan",
     "goalRow": "Målsumma",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "profilescroll:check": "node scripts/check-profile-scroll.mjs",
     "dayplan:check": "node scripts/check-home-day-plan.mjs",
     "dayplanedit:check": "node scripts/check-day-plan-editing.mjs",
+    "dayplanorder:check": "node scripts/check-day-plan-order-consistency.mjs",
     "nutritionui:check": "node scripts/check-nutrition-ring-ui.mjs",
     "prodconfig:check": "node scripts/check-production-config.mjs",
     "final5:check": "node scripts/check-final-five.mjs",

--- a/scripts/check-day-plan-editing.mjs
+++ b/scripts/check-day-plan-editing.mjs
@@ -42,33 +42,43 @@ const menu = readFileSync("features/menu/MenuScreen.tsx", "utf8");
 const today = readFileSync("features/home/TodayCard.tsx", "utf8");
 const rings = readFileSync("features/home/NutritionRingsCard.tsx", "utf8");
 
-// ── 1: a filled slot has a real edit handler ────────────────────────────
-check("Home-raderna har en Ändra-åtgärd, inte bara en pil",
+// ── 1: every slot row carries a real action ─────────────────────────────
+//
+// THIS SECTION USED TO PIN "Ändra". The four per-slot edit buttons are gone
+// on purpose: they were four separate doors to the same planner, which shows
+// all four slots anyway, and they left the rows unable to do the obvious
+// thing. The row action is now "Beställ" and there is ONE planner entry.
+// Editing itself is unchanged and still guarded below and in
+// check-day-plan-order-consistency.
+const nav = readFileSync("features/dayplan/dayPlanNavigation.ts", "utf8");
+check("Home-raderna har en åtgärd, inte bara en pil",
   home.includes("renderAction={(slot)")
-  && home.includes('t("planDay.edit")')
+  && home.includes('t("planDay.order")')
   && !homeCode.includes("ChevronRight"));
-check("Ändra öppnar planeraren", home.includes('pathname: "/planera-dagen"'));
-check("Ändra skickar med sloten", home.includes("params: { slot: wizardSlot }"));
-check("Ändra-knappen har ett eget a11y-namn per slot",
-  home.includes('t("planDay.editSlotAria", { slot: label })'));
+check("åtgärden går till menyn för sin slot",
+  home.includes("openMenuForSlot(slot.label)"));
+check("åtgärden har ett eget a11y-namn per slot",
+  home.includes('`${t("planDay.order")} — ${label}`'));
 
-// The route is reachable again. This is the actual regression: grep the whole
-// app for anything that navigates to it.
-const NAV = /(router\.(push|navigate|replace)\(|pathname:\s*)["'{][^\n]*planera-dagen/;
-const linkers = ["features/home/HomeDayPlan.tsx", "features/menu/PersonalMenuSection.tsx"]
+// The planner is still reachable — now through one shared entry rather than
+// four per-slot ones. It is the ORPHANED route that was the old regression.
+const NAV = /(router\.(push|navigate|replace)\(|pathname:\s*)["'{]?[^\n]*(planera-dagen|PLAN_DAY_ROUTE)/;
+const linkers = ["features/home/HomeDayPlan.tsx", "features/profile/ProfileScreen.tsx"]
   .filter((f) => NAV.test(readFileSync(f, "utf8")));
-check("/planera-dagen är inte längre föräldralös", linkers.length > 0);
+check("/planera-dagen är inte längre föräldralös", linkers.length >= 2);
+check("route-konstanten är delad, inte inskriven på varje ställe",
+  nav.includes('PLAN_DAY_ROUTE = "/planera-dagen"'));
 
 // ── 2: tapping a slot works EVERY time, not just the first ──────────────
 check("menyn läser fortfarande navKey", menu.includes("const navKey = params.navKey;")
   && menu.includes("[requestedCategory, navKey]"));
-check("Home SKICKAR navKey (det gjorde ingen tidigare)",
-  home.includes("navKey: String(Date.now())"));
-check("Home skickar fortfarande kategori och slot",
-  home.includes("category: categoryForSlot(wizardSlot)") && home.includes("slot: wizardSlot"));
+check("navKey skickas fortfarande (det gjorde ingen före dee9d85)",
+  nav.includes("navKey: String(now)") && home.includes("Date.now()"));
+check("kategori och slot skickas fortfarande",
+  nav.includes("category: categoryForSlot(slot)") && nav.includes("slot,"));
 
-// ── 3: row press and edit button are separate targets ───────────────────
-check("Ändra-knappen ligger UTANFÖR radens Pressable",
+// ── 3: row press and the row action are separate targets ────────────────
+check("radens åtgärd ligger UTANFÖR radens Pressable",
   /<\/Pressable>\s*\{renderAction\?\.\(slot\) \?\? null\}/.test(list));
 check("raden är fortfarande klickbar i hela sin bredd",
   list.includes("styles.slotMain") && list.includes("flex: 1"));

--- a/scripts/check-day-plan-order-consistency.mjs
+++ b/scripts/check-day-plan-order-consistency.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Regression guard: DAY-PLAN ROW ACTIONS + HOME/MENU NUTRITION EQUALITY.
+ *
+ * Three things this pins, and one of them is a bug that shipped:
+ *
+ *   1  Every slot row offers "Beställ" and goes to the menu — the same
+ *      destination the row press uses, via the same helper, so Lunch and
+ *      Middag can never quietly collapse into each other.
+ *
+ *   2  ONE "Planera din dag" entry on Home and one on Mina sidor, both on
+ *      the same route constant, replacing the four per-slot doors.
+ *
+ *   3  HOME SHOWS THE SAME SLOT TARGETS THE MENU RECOMMENDS AGAINST.
+ *      They did not agree. Home rendered `visibleSlotsFor`, the menu read
+ *      the STORED plan rows. In 4-meal mode those match, so it looked fine;
+ *      in 3-meal mode the snack's calories are scaled into the three main
+ *      meals and the two screens were up to 150 kcal apart on Lunch — the
+ *      menu picking M or L against a target the customer had never seen.
+ *      `savedPlanTargets` is now the single derivation and this exercises it.
+ *
+ * Run: npm run dayplanorder:check
+ */
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+
+const failures = [];
+const check = (name, ok) => { if (!ok) failures.push(name); };
+const codeOf = (path) =>
+  readFileSync(path, "utf8").replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
+// ── Load the real slot arithmetic (pure module, no app graph) ───────────
+const require_ = createRequire(import.meta.url);
+const ts = require_("typescript");
+const outDir = mkdtempSync(join(tmpdir(), "nutri-dporder-"));
+const js = ts.transpileModule(readFileSync("features/dayplan/dayPlanSlots.ts", "utf8"), {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 },
+}).outputText;
+writeFileSync(join(outDir, "dayPlanSlots.mjs"), js);
+const { visibleSlotsFor, savedPlanTargets } = await import(
+  pathToFileURL(join(outDir, "dayPlanSlots.mjs")).href
+);
+
+const home = codeOf("features/home/HomeDayPlan.tsx");
+const homeRaw = readFileSync("features/home/HomeDayPlan.tsx", "utf8");
+const list = readFileSync("features/dayplan/DayPlanSlotList.tsx", "utf8");
+const nav = readFileSync("features/dayplan/dayPlanNavigation.ts", "utf8");
+const profile = readFileSync("features/profile/ProfileScreen.tsx", "utf8");
+const menuRec = readFileSync("features/menu/mealRecommendation.ts", "utf8");
+
+// ── A: every slot row says "Beställ", none says "Ändra" ─────────────────
+check("raderna erbjuder Beställ", homeRaw.includes('t("planDay.order")'));
+check("Ändra-knappen är borta från Home",
+  !home.includes('t("planDay.edit")') && !home.includes("planDay.editSlotAria"));
+check("knappen renderas för VARJE slot, inte villkorat på etikett",
+  /renderAction=\{\(slot\) => \{[\s\S]{0,400}?parseSlot\(slot\.label\)/.test(homeRaw)
+  && !/slot\.label === "(Frukost|Lunch|Middag|Mellanmål)"/.test(home));
+
+// ── B: Beställ and the row press share ONE navigation ───────────────────
+check("radtryck och Beställ anropar samma helper",
+  (home.match(/openMenuForSlot\(slot\.label\)/g) ?? []).length === 2);
+check("helpern bygger meny-href:en, inte skärmen",
+  home.includes("menuHrefForSlot(wizardSlot, Date.now())")
+  && !home.includes('pathname: "/(tabs)/meny"'));
+check("helpern skickar kategori, slot och navKey",
+  nav.includes("category: categoryForSlot(slot)")
+  && nav.includes("slot,")
+  && nav.includes("navKey: String(now)"));
+check("Home navigerar inte längre till planeraren per slot",
+  !/router\.push\(\{\s*pathname:\s*PLAN_DAY_ROUTE/.test(home)
+  && !home.includes('params: { slot: wizardSlot }'));
+
+// Lunch and Middag must resolve to the same chip but different slots.
+const menuRecCode = codeOf("features/menu/mealRecommendation.ts");
+check("Lunch och Middag delar kategori men behåller sin slot",
+  menuRecCode.includes('if (slot === "Frukost") return "frukost"')
+  && menuRecCode.includes('if (slot === "Mellanmål") return "mellanmal"')
+  && menuRecCode.includes('return "huvudmaltider"'));
+check("parseSlot accepterar exakt de fyra etiketterna",
+  menuRec.includes('value === "Frukost" || value === "Lunch" || value === "Middag" || value === "Mellanmål"'));
+
+// ── C: one shared "Planera din dag" CTA under the list ──────────────────
+check("Home har EN planera-CTA", (homeRaw.match(/PLAN_DAY_ROUTE/g) ?? []).length === 2);
+check("CTA:n ligger under slot-listan",
+  homeRaw.indexOf("<DayPlanSlotList") < homeRaw.indexOf("styles.planCta"));
+check("CTA:n använder den delade route-konstanten",
+  home.includes("router.push(PLAN_DAY_ROUTE)") && nav.includes('PLAN_DAY_ROUTE = "/planera-dagen"'));
+check("CTA:n skickar ingen slot (hela planeraren)",
+  !/PLAN_DAY_ROUTE,\s*params/.test(home));
+
+// ── D: Mina sidor entry, under Din aktiva plan ──────────────────────────
+check("Mina sidor har en planera-entry", profile.includes('t("profile.planDay")'));
+check("den använder SAMMA route-konstant, ingen egen navigation",
+  profile.includes("router.push(PLAN_DAY_ROUTE)")
+  && profile.includes('from "@/features/dayplan/dayPlanNavigation"'));
+check("den ligger under Din aktiva plan, före Mitt konto",
+  profile.indexOf("profile.sectionActivePlan") < profile.indexOf("styles.planDayCard")
+  && profile.indexOf("styles.planDayCard") < profile.indexOf("profile.myAccount"));
+check("den ser ut som plansektionen, inte som en inställningsrad",
+  /planDayCard: \{[\s\S]{0,260}?backgroundColor: "#17171A"/.test(profile));
+
+// ── E: HOME == MENU, exercised on real numbers ──────────────────────────
+const slot = (l, c, p, cb, f) => ({
+  label: l, calories: c, proteinG: p, carbsG: cb, fatG: f, timingPurpose: "",
+});
+const stored = [
+  slot("Frukost", 500, 30, 50, 15),
+  slot("Lunch", 600, 45, 60, 18),
+  slot("Middag", 500, 40, 45, 16),
+  slot("Mellanmål", 400, 20, 40, 12),
+];
+
+let mismatch = null;
+for (const mealCount of [4, 3]) {
+  const plan = { mealCount, meals: stored };
+  // What Home renders …
+  const homeRows = savedPlanTargets(plan);
+  // … and what the menu resolves a slot target from — the same call, which
+  // is the point: one derivation, not two that happen to agree.
+  for (const row of homeRows) {
+    const target = savedPlanTargets(plan).find((m) => m.label === row.label);
+    for (const key of ["calories", "proteinG", "carbsG", "fatG"]) {
+      if (row[key] !== target[key]) mismatch = `${mealCount}-meal ${row.label} ${key}`;
+    }
+  }
+}
+check(`Home och Meny läser samma tal (avvikelse: ${mismatch})`, mismatch === null);
+
+// The derivation must actually DO the 3-meal scaling — otherwise the two
+// sides agree only because both are wrong.
+const four = savedPlanTargets({ mealCount: 4, meals: stored });
+const three = savedPlanTargets({ mealCount: 3, meals: stored });
+check("4 måltider visar alla fyra slots orörda",
+  four.length === 4 && four.find((m) => m.label === "Lunch").calories === 600);
+check("3 måltider släpper mellanmålet och skalar upp",
+  three.length === 3
+  && !three.some((m) => m.label === "Mellanmål")
+  && three.find((m) => m.label === "Lunch").calories > 600);
+check("3 måltider summerar fortfarande till dagens mål",
+  Math.abs(three.reduce((s, m) => s + m.calories, 0) - 2000) <= 3);
+check("måltidsantalet kommer från PLANEN, inte från en vy",
+  /plan\?\.mealCount === 3 \? "3" : "4"/.test(readFileSync("features/dayplan/dayPlanSlots.ts", "utf8")));
+check("en tom/saknad plan kraschar inte",
+  savedPlanTargets(null).length === 0 && savedPlanTargets({ meals: [] }).length === 0);
+
+// ── F: the toggle can no longer create a second set of numbers ──────────
+check("Home har ingen egen 3/4-toggle längre",
+  !home.includes("onMealTabChange={setMealTab}") && !home.includes("setMealTab"));
+check("Home härleder måltidsantalet ur den sparade planen",
+  home.includes('saved?.mealCount === 3 ? "3" : "4"'));
+check("listan döljer pillren när de inte går att ändra",
+  list.includes("onMealTabChange?: (tab:") && list.includes("{onMealTabChange ? ("));
+check("planeraren behåller sin toggle (där den faktiskt sparas)",
+  readFileSync("features/dayplan/PlanDayScreen.tsx", "utf8").includes("onMealTabChange={setMealTab}"));
+
+// ── G: the backdrop dismiss we shipped must still be there ──────────────
+const planner = codeOf("features/dayplan/PlanDayScreen.tsx");
+check("slot-editorn stängs fortfarande på backdrop-tryck",
+  planner.includes("onPress={closeEditor}") && planner.includes("StyleSheet.absoluteFill"));
+check("backdroppen sparar fortfarande ingenting",
+  /const closeEditor = \(\) => setEditingIdx\(null\);/.test(planner));
+check("backdroppen är fortfarande avstängd under sparning",
+  planner.includes('disabled={saveStatus === "saving"}'));
+
+// ── i18n ────────────────────────────────────────────────────────────────
+for (const locale of ["sv", "en", "da"]) {
+  const json = JSON.parse(readFileSync(`i18n/locales/${locale}.json`, "utf8"));
+  check(`${locale}: planDay.order finns`,
+    typeof json.planDay?.order === "string" && json.planDay.order.length > 0);
+  check(`${locale}: planDay.title finns`, typeof json.planDay?.title === "string");
+  check(`${locale}: profile.planDay + planDaySub finns`,
+    typeof json.profile?.planDay === "string" && typeof json.profile?.planDaySub === "string");
+}
+const sv = JSON.parse(readFileSync("i18n/locales/sv.json", "utf8"));
+const en = JSON.parse(readFileSync("i18n/locales/en.json", "utf8"));
+const da = JSON.parse(readFileSync("i18n/locales/da.json", "utf8"));
+check("copyn är rätt på alla tre språk",
+  sv.planDay.order === "Beställ" && en.planDay.order === "Order" && da.planDay.order === "Bestil");
+check("planera-copyn återanvänds, inte dubbleras",
+  sv.profile.planDay === sv.planDay.title
+  && en.profile.planDay === en.planDay.title
+  && da.profile.planDay === da.planDay.title);
+
+// ── Rapport ─────────────────────────────────────────────────────────────
+if (failures.length > 0) {
+  console.error("✗ Day-plan order/consistency guard failed:\n");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log("✓ Day-plan order + nutrition consistency holds:");
+console.log("    every slot row offers Beställ, and it goes where the row goes");
+console.log("    Lunch and Middag keep their own slot through one shared helper");
+console.log("    one Planera din dag entry on Home, one on Mina sidor, same route");
+console.log("    Home and the menu read slot targets from ONE derivation");
+console.log("    3-meal scaling is applied by the plan's own meal count");
+console.log("    the slot editor still dismisses on backdrop without saving");

--- a/scripts/check-day-plan-order-consistency.mjs
+++ b/scripts/check-day-plan-order-consistency.mjs
@@ -130,6 +130,64 @@ for (const mealCount of [4, 3]) {
 }
 check(`Home och Meny läser samma tal (avvikelse: ${mismatch})`, mismatch === null);
 
+// ── E2: HOME_TARGET == MENU_TARGET, slot by slot, named explicitly ──────
+// Spelled out per slot rather than only in the loop above, so a failure
+// names the meal rather than "something diverged".
+for (const mealCount of [4, 3]) {
+  const plan = { mealCount, meals: stored };
+  const rows = savedPlanTargets(plan);
+  const slots = mealCount === 3
+    ? ["Frukost", "Lunch", "Middag"]
+    : ["Frukost", "Mellanmål", "Lunch", "Middag"];
+  for (const name of slots) {
+    const homeRow = rows.find((m) => m.label === name);
+    const menuRow = savedPlanTargets(plan).find((m) => m.label === name);
+    check(
+      `${mealCount} måltider: HOME_TARGET == MENU_TARGET för ${name}`,
+      homeRow != null &&
+        menuRow != null &&
+        homeRow.calories === menuRow.calories &&
+        homeRow.proteinG === menuRow.proteinG &&
+        homeRow.carbsG === menuRow.carbsG &&
+        homeRow.fatG === menuRow.fatG
+    );
+  }
+  // Lunch and Middag must remain distinct rows, not one collapsed target.
+  const lunch = rows.find((m) => m.label === "Lunch");
+  const dinner = rows.find((m) => m.label === "Middag");
+  check(`${mealCount} måltider: Lunch och Middag är skilda mål`,
+    lunch != null && dinner != null && lunch.calories !== dinner.calories);
+}
+
+// ── E3: the MENU SHOWS the target, it does not only compute with it ─────
+// This was the whole reported complaint: the number existed but was never
+// on screen, so the only thing to compare Home against was a meal card.
+const menuScreen = codeOf("features/menu/MenuScreen.tsx");
+const banner = codeOf("features/menu/SlotTargetBanner.tsx");
+check("menyn renderar slotens mål, inte bara räknar med det",
+  menuScreen.includes("<SlotTargetBanner slot={activeSlot} target={activeSlotTarget} />"));
+check("bannern visas bara när menyn öppnats FÖR den sloten",
+  menuScreen.includes("activeSlot && requestedSlot === activeSlot"));
+check("samma target-objekt driver både bannern och M/L-valet",
+  menuScreen.includes("recommendSize(item.meal, activeSlotTarget, activeSlot)")
+  && (menuScreen.match(/activeSlotTarget/g) ?? []).length >= 3);
+check("bannern räknar inte om något själv",
+  !/[*/]\s*\d|Math\.round|Math\.max|multiplier/.test(banner));
+check("bannern visar inget när målet saknas",
+  banner.includes("if (!target || target.calories <= 0) return null;"));
+check("bannern visar alla fyra makrona",
+  banner.includes("target.calories") && banner.includes("target.proteinG")
+  && banner.includes("target.carbsG") && banner.includes("target.fatG"));
+
+// ── E4: target and meal nutrition are never conflated ───────────────────
+const mealCard = codeOf("features/menu/MealCard.tsx");
+check("MealCard visar MÅLTIDENS näring, aldrig slotens mål",
+  !mealCard.includes("slotTarget(") && !mealCard.includes("savedPlanTargets"));
+check("MealCard får bara rekommendationen, inte targetet",
+  /recommendation\?: MealRecommendation \| null/.test(readFileSync("features/menu/MealCard.tsx", "utf8")));
+check("copyn säger vilket tal som är vilket",
+  banner.includes('t("menu.slotTarget.label")') && banner.includes('t("menu.slotTarget.mealNote")'));
+
 // The derivation must actually DO the 3-meal scaling — otherwise the two
 // sides agree only because both are wrong.
 const four = savedPlanTargets({ mealCount: 4, meals: stored });
@@ -174,6 +232,10 @@ for (const locale of ["sv", "en", "da"]) {
   check(`${locale}: planDay.title finns`, typeof json.planDay?.title === "string");
   check(`${locale}: profile.planDay + planDaySub finns`,
     typeof json.profile?.planDay === "string" && typeof json.profile?.planDaySub === "string");
+  check(`${locale}: menu.slotTarget-copyn finns och skiljer målet från måltiden`,
+    typeof json.menu?.slotTarget?.label === "string"
+    && typeof json.menu?.slotTarget?.mealNote === "string"
+    && json.menu.slotTarget.mealNote.length > 20);
 }
 const sv = JSON.parse(readFileSync("i18n/locales/sv.json", "utf8"));
 const en = JSON.parse(readFileSync("i18n/locales/en.json", "utf8"));
@@ -196,5 +258,7 @@ console.log("    every slot row offers Beställ, and it goes where the row goes"
 console.log("    Lunch and Middag keep their own slot through one shared helper");
 console.log("    one Planera din dag entry on Home, one on Mina sidor, same route");
 console.log("    Home and the menu read slot targets from ONE derivation");
+console.log("    the menu SHOWS that target, per slot, in 3- and 4-meal plans");
+console.log("    a meal card still shows the meal's own nutrition, and says so");
 console.log("    3-meal scaling is applied by the plan's own meal count");
 console.log("    the slot editor still dismisses on backdrop without saving");

--- a/scripts/check-home-day-plan.mjs
+++ b/scripts/check-home-day-plan.mjs
@@ -53,10 +53,16 @@ check("Home återanvänder den delade komponenten, ingen kopia",
   home.includes("DayPlanSlotList") && home.includes("visibleSlotsFor"));
 check("Home lägger inte till egna nätverksanrop",
   home.includes("useTodayNutritionQuery") && home.includes("useTodayDayPlanQuery"));
-check("Home navigerar till menyn med kategori OCH slot",
-  home.includes('pathname: "/(tabs)/meny"')
-  && home.includes("categoryForSlot(wizardSlot)")
-  && home.includes("slot: wizardSlot"));
+// Home no longer builds the menu href inline — it moved to
+// features/dayplan/dayPlanNavigation.ts so the row press and the row's
+// "Beställ" button cannot drift apart. This assertion used to require the
+// inline construction, which is precisely what got duplicated.
+const dayPlanNav = readFileSync("features/dayplan/dayPlanNavigation.ts", "utf8");
+check("Home navigerar till menyn med kategori OCH slot, via den delade helpern",
+  home.includes("menuHrefForSlot(wizardSlot, Date.now())")
+  && dayPlanNav.includes('pathname: "/(tabs)/meny"')
+  && dayPlanNav.includes("category: categoryForSlot(slot)")
+  && dayPlanNav.includes("slot,"));
 check("Home sparar ingen plan (bara planeraren skriver)",
   !home.includes("saveTodayDayPlan"));
 


### PR DESCRIPTION
The four commits physically QA'd on device, on top of the build 12 tip (`fc4d90a`). This is the source for build 13.

## What changed

**Row actions are "Bestall", not "Andra".** Each of the four rows opened the planner on its own slot — four doors to one screen that shows all four slots anyway, and it left the rows unable to do the thing you come to Home for. Frukost goes to `frukost`, Mellanmal to `mellanmal`, Lunch and Middag both to `huvudmaltider` but each carrying its own slot, because the menu has no lunch tab and no dinner tab and it is the slot that decides the recommended portion.

The row press and the button call the same helper. They went to the same place before too, by two separate inline constructions — and two places that navigate "to the menu for this slot" drift the first time either is touched, silently, with Middag served lunch portions.

**One source of truth for slot nutrition.** Home rendered `visibleSlotsFor(tab, meals)`; the menu read the stored rows off the saved plan. Those agree in 4-meal mode, so it looked fine. In 3-meal mode the snack is dropped and its calories scaled into the three main meals: on a 2000 kcal plan that is Lunch at 750 on Home and 600 in the menu, and the menu recommended M or L against a target the customer had never seen. `savedPlanTargets` is now the single derivation, keyed on the plan's own `mealCount`.

Home's 3/4 toggle went with it. It only ever changed what Home displayed — it wrote nothing — so switching it moved Home away from the saved plan while the menu kept using the stored one. The meal count is changed in the planner, where it is saved. The planner keeps its toggle.

**The menu now SHOWS that target.** It already knew it; it just never rendered it, so the only thing to compare Home against was a meal card. Opening the menu from a day-plan row now shows "LUNCH - DITT MAL" above the list, rendering the exact object Home renders from.

Two numbers, said out loud: the banner is the TARGET, a meal card is that MEAL's own nutrition at the selected size — the numbers the cart carries. Both true, different quantities, and a line under the target says which is which. MealCard is untouched and still never sees a slot target.

**One "Planera din dag" entry**, on Home under the four rows and on Mina sidor under "Din aktiva plan", both on the same route constant. Existing copy reused (`planDay.title`, `profile.planDay`, `profile.planDaySub` — already translated and unused); the only new key is `planDay.order`.

## Verification

typecheck, lint and 18 guards: 0 failures. Physical QA on device: green.

New `dayplanorder:check` asserts HOME_TARGET == MENU_TARGET slot by slot in 3- and 4-meal plans, that Lunch and Middag stay distinct, that the menu renders the target rather than only computing with it, and that MealCard never reads a slot target.

Three existing guard assertions were updated because they described the old product: two required "Andra" on the rows and Home building the menu href inline — which is exactly the duplication removed here.

## Scope

No auth, no backend, no frontend. Day plan, menu target display, profile entry point and i18n only.
