### PR TITLE
fix: make personalized meals target-driven

### DIFF
--- a/features/anpassar/optimizer.ts
+++ b/features/anpassar/optimizer.ts
@@ -4,12 +4,22 @@ import type { ApiMealDistribution } from "@/services/api/nutrition";
 import type { ApiContainerType } from "@/services/api/containerTypes";
 
 /**
- * Verbatim port of Nutri-Frontend's src/features/heldag/optimizer.ts (the
- * web keeps it under heldag/ because "Sätt upp din dag" shares it; on mobile
- * it lives with anpassar since that's its only consumer so far). The
- * iterative macro-fit (calorie pre-scale → per-role damped scaling →
- * re-scale → fat→protein swap → convergence check) must produce identical
- * gram amounts on both platforms — do not "improve" it here.
+ * Meal-level portion fit. Lives under anpassar/ because that was its first
+ * consumer; personalizedMenu and heldagBuilder use it too.
+ *
+ * THIS NO LONGER MATCHES Nutri-Frontend's src/features/heldag/optimizer.ts.
+ * The web still runs the original iterative fit (calorie pre-scale → per-role
+ * damped scaling → kcal re-scale → fat→protein swap → convergence check).
+ * That model treated kcal as a free knob, so it could hit the calorie target
+ * with the wrong composition — e.g. a 1029 kcal / 50P / 133C target coming
+ * back as 1013 kcal / 63P / 96C / 43F: calories right, 13 g too much protein
+ * and 37 g too few carbs. Mobile deliberately diverges. Re-sync the web to
+ * this model before assuming the two platforms agree on grams.
+ *
+ * The rule this encodes: kcal is not optimised for. It falls out of
+ * 4·protein + 4·carbs + 9·fat. Priority is protein, then carbs, with kcal as a
+ * read-out and fat best-effort. A single residual pass per macro, in order,
+ * then stop — no global rescale, no swaps, no convergence loop.
  */
 
 export type WizardSlot = "Frukost" | "Lunch" | "Middag" | "Mellanmål";
@@ -25,7 +35,11 @@ type MacroRole = "protein" | "carb" | "fat" | "fixed";
 const CATEGORY_ROLE: Record<string, MacroRole> = {
   Protein: "protein",
   Baser: "carb",
-  Frukt: "carb",
+  // Fruit is flavour, presentation and recipe identity — the apple in an apple
+  // pie, the berries on a Cream of Rice. It is NOT a carb source to inflate
+  // until a carb target is met, so it holds its recipe grams. Adjustable carbs
+  // are the bases: rice, sweet potato, quinoa, potato, oats, rice flour.
+  Frukt: "fixed",
   Kolhydrater: "carb",
   Grönsaker: "fixed",
   Mejeri: "fixed",
@@ -47,16 +61,67 @@ type WorkItem = {
   maxG: number;
 };
 
-const ITERATIONS = 3;
-const DAMPING = 0.7;
-const MAX_DELTA_G = 12;
-const FAT_REDUCE_MAX_G = 12;
+type MacroKey = "proteinPerG" | "carbsPerG" | "fatPerG";
 
-function kcalFromAmounts(work: WorkItem[], amounts: number[]): number {
-  return work.reduce(
-    (sum, w, i) => sum + amounts[i] * (w.proteinPerG * 4 + w.carbsPerG * 4 + w.fatPerG * 9),
+/**
+ * One residual pass over a single role.
+ *
+ * Everything outside the role is a constant — its real macro contribution is
+ * counted first, because "fixed" means fixed in grams, not nutritionally
+ * invisible: keso carries protein, seeds carry fat, honey carries carbs.
+ * Whatever the target still needs after those constants is what the role has
+ * to deliver, so the free members scale by residual / current, which keeps
+ * their recipe ratios and leaves the dish looking like itself.
+ *
+ * Members that would leave their own min/max are pinned exactly to the bound
+ * and drop out of the free set; the residual is then recomputed against them
+ * as constants too and redistributed over whoever is still free. That repeats
+ * until nothing new clamps or nobody is free — at most once per member, so it
+ * terminates. It is redistribution INSIDE one role, not a convergence loop:
+ * no kcal iteration, no damping, no step cap, no cross-role compensation.
+ */
+function residualPass(
+  work: WorkItem[],
+  amounts: number[],
+  role: MacroRole,
+  macro: MacroKey,
+  targetTotal: number
+): void {
+  const roleIdx = work.map((_, i) => i).filter((i) => work[i].role === role);
+  if (roleIdx.length === 0 || targetTotal <= 0) return;
+
+  const outsideRole = work.reduce(
+    (sum, w, i) => (w.role === role ? sum : sum + amounts[i] * w[macro]),
     0
   );
+
+  const free = new Set(roleIdx);
+  while (free.size > 0) {
+    const fromClamped = roleIdx
+      .filter((i) => !free.has(i))
+      .reduce((sum, i) => sum + amounts[i] * work[i][macro], 0);
+    const fromFree = [...free].reduce((sum, i) => sum + amounts[i] * work[i][macro], 0);
+    // Nobody still free carries this macro — nothing left to steer with.
+    if (fromFree <= 0) return;
+
+    // A negative residual means the constants already overshoot on their own.
+    // Then the free members scale toward zero and land on their mins — we do
+    // not "fix" the overshoot by inflating some other macro.
+    const scale = Math.max(0, (targetTotal - outsideRole - fromClamped) / fromFree);
+
+    let newlyClamped = false;
+    for (const i of [...free]) {
+      const desired = amounts[i] * scale;
+      const bounded = Math.max(work[i].minG, Math.min(work[i].maxG, desired));
+      if (bounded !== desired) {
+        free.delete(i);
+        newlyClamped = true;
+      }
+      amounts[i] = bounded;
+    }
+    // The scale applied cleanly, so the residual is met exactly. Done.
+    if (!newlyClamped) return;
+  }
 }
 
 export function optimizeIngredients(
@@ -86,100 +151,25 @@ export function optimizeIngredients(
 
   if (work.length === 0) return [];
 
-  const currentKcal = kcalFromAmounts(work, amounts);
-  if (currentKcal > 0 && target.calories > 0) {
-    const calScale = target.calories / currentKcal;
-    for (let i = 0; i < work.length; i++) {
-      if (work[i].role === "fixed") continue;
-      amounts[i] = Math.max(work[i].minG, Math.min(work[i].maxG, amounts[i] * calScale));
-    }
+  // 1. Start from the recipe, inside every ingredient's own limits.
+  for (let i = 0; i < work.length; i++) {
+    amounts[i] = Math.max(work[i].minG, Math.min(work[i].maxG, amounts[i]));
   }
 
-  for (let iter = 0; iter < ITERATIONS; iter++) {
-    for (const role of ["protein", "carb", "fat"] as const) {
-      const indices = work.map((w, i) => ({ w, i })).filter(({ w }) => w.role === role);
-      if (indices.length === 0) continue;
+  // 2–3. Fixed (and fat) ingredients stay on their recipe grams and count as
+  //      real contributions; the protein role covers what protein is left.
+  residualPass(work, amounts, "protein", "proteinPerG", target.proteinG);
 
-      const targetG =
-        role === "protein" ? target.proteinG : role === "carb" ? target.carbsG : target.fatG;
+  // 4. Same for the carb base. If it saturates, it saturates — the shortfall
+  //    is NOT made up with extra protein or fat.
+  residualPass(work, amounts, "carb", "carbsPerG", target.carbsG);
 
-      const currentFromRole = indices.reduce((sum, { w, i }) => {
-        const perG =
-          role === "protein" ? w.proteinPerG : role === "carb" ? w.carbsPerG : w.fatPerG;
-        return sum + amounts[i] * perG;
-      }, 0);
+  // 5. The carb base carries some protein of its own, so one short
+  //    stabilising protein pass. Not a new loop.
+  residualPass(work, amounts, "protein", "proteinPerG", target.proteinG);
 
-      if (currentFromRole <= 0 || targetG <= 0) continue;
-
-      const scale = targetG / currentFromRole;
-      const dampedScale = 1 + (scale - 1) * DAMPING;
-
-      for (const { w, i } of indices) {
-        const desired = Math.max(w.minG, Math.min(w.maxG, amounts[i] * dampedScale));
-        const delta = Math.max(-MAX_DELTA_G, Math.min(MAX_DELTA_G, desired - amounts[i]));
-        amounts[i] = amounts[i] + delta;
-      }
-    }
-
-    const postIterKcal = kcalFromAmounts(work, amounts);
-    if (postIterKcal > 0 && target.calories > 0) {
-      const reScale = target.calories / postIterKcal;
-      for (let i = 0; i < work.length; i++) {
-        if (work[i].role === "fixed") continue;
-        amounts[i] = Math.max(work[i].minG, Math.min(work[i].maxG, amounts[i] * reScale));
-      }
-    }
-
-    const currentProtein = work.reduce((sum, w, i) => sum + amounts[i] * w.proteinPerG, 0);
-    if (currentProtein < target.proteinG) {
-      const fatIndices = work.map((w, i) => ({ w, i })).filter(({ w }) => w.role === "fat");
-      const proteinIndices = work.map((w, i) => ({ w, i })).filter(({ w }) => w.role === "protein");
-
-      if (fatIndices.length > 0 && proteinIndices.length > 0) {
-        let freedKcal = 0;
-
-        for (const { w, i } of fatIndices) {
-          const reduction = Math.min(FAT_REDUCE_MAX_G, amounts[i] - w.minG);
-          if (reduction <= 0) continue;
-          const kcalPerG = w.proteinPerG * 4 + w.carbsPerG * 4 + w.fatPerG * 9;
-          freedKcal += reduction * kcalPerG;
-          amounts[i] -= reduction;
-        }
-
-        if (freedKcal > 0) {
-          const totalProteinKcalPerG = proteinIndices.reduce(
-            (sum, { w }) => sum + (w.proteinPerG * 4 + w.carbsPerG * 4 + w.fatPerG * 9),
-            0
-          );
-
-          for (const { w, i } of proteinIndices) {
-            if (totalProteinKcalPerG <= 0) break;
-            const kcalPerG = w.proteinPerG * 4 + w.carbsPerG * 4 + w.fatPerG * 9;
-            const share = kcalPerG / totalProteinKcalPerG;
-            const addG = (freedKcal * share) / kcalPerG;
-            amounts[i] = Math.min(w.maxG, amounts[i] + addG);
-          }
-        }
-
-        const postSwapKcal = kcalFromAmounts(work, amounts);
-        if (postSwapKcal > 0 && target.calories > 0) {
-          const swapReScale = target.calories / postSwapKcal;
-          for (let i = 0; i < work.length; i++) {
-            if (work[i].role === "fixed") continue;
-            amounts[i] = Math.max(work[i].minG, Math.min(work[i].maxG, amounts[i] * swapReScale));
-          }
-        }
-      }
-    }
-
-    const finalProtein = work.reduce((sum, w, i) => sum + amounts[i] * w.proteinPerG, 0);
-    const finalKcal = kcalFromAmounts(work, amounts);
-    const proteinOk = Math.abs(finalProtein - target.proteinG) <= 3;
-    const caloriesOk =
-      target.calories > 0 && Math.abs(finalKcal - target.calories) / target.calories <= 0.03;
-    if (proteinOk && caloriesOk) break;
-  }
-
+  // 6. Stop. No global kcal rescale, no fat→protein swap, no convergence
+  //    loop — kcal is whatever these grams add up to.
   return work
     .map((w, i) => ({
       ingredientId: w.ingredientId,

--- a/features/cart/CartScreen.tsx
+++ b/features/cart/CartScreen.tsx
@@ -951,14 +951,22 @@ function CartItemCard({ item }: { item: CartItem }) {
           fiberG: Math.round(item.meal.macros.fiberG * macroMult),
         });
 
-  const totalGramsBase = item.meal.ingredients.reduce((s, ing) => s + (ing.amountG ?? 0), 0);
-  const grams =
-    !isDrink && totalGramsBase > 0 ? `${Math.round(totalGramsBase * macroMult)}g` : null;
+  // A custom/personalized line was ordered at the optimizer's grams, not at
+  // the recipe's — and no size multiplier applies to it.
+  const totalGramsBase =
+    item.isCustom && item.customIngredients
+      ? item.customIngredients.reduce((s, ing) => s + (ing.amountG ?? 0), 0)
+      : Math.round(item.meal.ingredients.reduce((s, ing) => s + (ing.amountG ?? 0), 0) * macroMult);
+  const grams = !isDrink && totalGramsBase > 0 ? `${totalGramsBase}g` : null;
   const sizeShort = isDrink
     ? item.drink?.volumeML
       ? `${item.drink.volumeML} ml`
       : null
-    : (SIZE_LABEL_SHORT[item.sizeId] ?? size?.label ?? "M");
+    : // A personalized line has no size — an "M"/"L" badge would name a
+      // portion that does not exist for it.
+      item.isCustom
+      ? null
+      : (SIZE_LABEL_SHORT[item.sizeId] ?? size?.label ?? "M");
   const isUnavailable = item.meal.available === false;
   const canSwitchSize = !isDrink && !item.isCustom && item.meal.portionMode !== "fixed";
 
@@ -1003,8 +1011,9 @@ function CartItemCard({ item }: { item: CartItem }) {
                 {sizeShort || grams ? (
                   <View style={styles.sizePill}>
                     <ThemedText style={styles.sizePillText}>
-                      {sizeShort}
-                      {grams ? ` · ${grams}` : ""}
+                      {/* A personalized line has no size, so the pill is
+                          grams alone — not a dangling " · " separator. */}
+                      {[sizeShort, grams].filter(Boolean).join(" · ")}
                     </ThemedText>
                   </View>
                 ) : null}

--- a/features/menu/MealCard.tsx
+++ b/features/menu/MealCard.tsx
@@ -114,9 +114,6 @@ export function MealCard({ meal, availability, recommendation = null }: MealCard
     if (fallback) setSelectedSize(fallback.id);
   }, [availability, selectedSize, isFixed, stockBySize]);
 
-  const effectiveSize = isFixed ? "medium" : selectedSize;
-  const size = CUSTOMER_SIZE_OPTIONS.find((s) => s.id === effectiveSize) ?? CUSTOMER_SIZE_OPTIONS[0];
-
   // ── The personally computed meal (the real Anpassar engine) ──────────
   //
   // ready → grams/macros/price come from the BACKEND calculation for this
@@ -128,11 +125,30 @@ export function MealCard({ meal, availability, recommendation = null }: MealCard
   // must know whether L is genuinely a different portion before offering
   // it: when every ingredient is already saturated at max for M, the L
   // optimization returns the exact same grams and "L" would be a fake
-  // upgrade. The queries are cached per (user, target, meal, size) with a
-  // 5-min staleTime and shared with MealDetailScreen, so this is one extra
-  // calculate call per card, not per render.
-  const personalMedium = usePersonalizedMeal(meal, "medium");
-  const personalLarge = usePersonalizedMeal(meal, "large");
+  // upgrade. Since the personal target is no longer scaled by size (see
+  // personalizedMenu.ts) the two now always agree for a personalized meal,
+  // so L hides itself through the SAME rule rather than a second mechanism
+  // — and both hooks share one cache row, so it is one calculate call.
+  //
+  // The slot rides along so the tailoring matches the row the customer
+  // tapped on Home: at 12:00 a Middag card must not be served Lunch's
+  // target just because the clock says lunchtime.
+  const personalSlot = recommendation?.slot ?? null;
+  const personalMedium = usePersonalizedMeal(meal, "medium", personalSlot);
+  const personalLarge = usePersonalizedMeal(meal, "large", personalSlot);
+
+  // PERSONALIZED-ONLY. Once a personal portion exists it REPLACES the M/L
+  // choice — the customer sees one meal, computed for their own target, and
+  // there is no size left to pick. So no size may ride along downstream
+  // either: "medium" is the neutral value, and the one the backend hardcodes
+  // for custom lines anyway (OrdersController: Size = "medium" when
+  // MealId is null). Storing "large" here would have re-applied a 1.2×
+  // multiplier to the cart's weight display and put an "L" badge on a
+  // portion the kitchen must plate by grams.
+  const personalizedOnly = personalMedium.status === "ready";
+  const effectiveSize = isFixed || personalizedOnly ? "medium" : selectedSize;
+  const size = CUSTOMER_SIZE_OPTIONS.find((s) => s.id === effectiveSize) ?? CUSTOMER_SIZE_OPTIONS[0];
+
   const personal = effectiveSize === "large" ? personalLarge : personalMedium;
   const personalData = personal.status === "ready" ? personal.data : null;
 
@@ -174,7 +190,9 @@ export function MealCard({ meal, availability, recommendation = null }: MealCard
   // masquerade as it — the price slot shows a placeholder instead.
   const priceHidden = personal.status === "loading";
 
-  const hasRecommendation = !isFixed && recSizeId !== null;
+  // A size recommendation is meaningless when there are no sizes to choose
+  // between — personalized-only owns the portion outright.
+  const hasRecommendation = !isFixed && !personalizedOnly && recSizeId !== null;
   const recSizeLabel =
     CUSTOMER_SIZE_OPTIONS.find((s) => s.id === recSizeId)?.label ?? recSizeId ?? "";
   const isRecommendedSelected = hasRecommendation && effectiveSize === recSizeId;
@@ -381,9 +399,12 @@ export function MealCard({ meal, availability, recommendation = null }: MealCard
       </View>
       </Pressable>
 
-      {/* Footer: size selector (M/L) — small is customer-hidden, web parity */}
+      {/* Footer: size selector (M/L) — small is customer-hidden, web parity.
+          Personalized-only renders no selector at all: the portion is the
+          customer's own, and an M/L next to it would be a second, competing
+          answer to the same question. */}
       <View style={styles.footer}>
-        {!isFixed ? (
+        {!isFixed && !personalizedOnly ? (
           <View style={styles.sizeGroup}>
             {/* When personal M and L are provably the same portion, L is not
                 rendered — a second button for the identical recipe would be a

--- a/features/menu/MealDetailScreen.tsx
+++ b/features/menu/MealDetailScreen.tsx
@@ -155,19 +155,28 @@ export function MealDetailScreen() {
     if (fallback) setSelectedSize(fallback.id);
   }, [availability, selectedSize, stockBySize]);
 
-  const effectiveSize = isFixed ? "medium" : selectedSize;
+  // ── The personally computed meal ─────────────────────────────────────
+  //
+  // Computed through the SAME engine the Anpassar wizard used (optimizer
+  // grams → backend /custom-meal/calculate for nutrition and öre-precise
+  // price), against the customer's OWN slot target — the size multiplier no
+  // longer touches that target (see personalizedMenu.ts), so for a
+  // personalized meal M and L resolve to the same portion and the shared
+  // equivalence rule below removes the fake L choice.
+  //
+  // `slot` is the one the customer navigated from (route param) or the
+  // meal's own slot — the same value SlotTargetBanner renders.
+  const personalMedium = usePersonalizedMeal(meal, "medium", slot);
+  const personalLarge = usePersonalizedMeal(meal, "large", slot);
+
+  // PERSONALIZED-ONLY — same rule as MealCard: a computed personal portion
+  // replaces the size choice, so no size is offered and none rides along to
+  // the cart or the order (see MealCard for the full reasoning).
+  const personalizedOnly = personalMedium.status === "ready";
+  const effectiveSize = isFixed || personalizedOnly ? "medium" : selectedSize;
   const sizeDef =
     CUSTOMER_SIZE_OPTIONS.find((s) => s.id === effectiveSize) ?? CUSTOMER_SIZE_OPTIONS[0];
 
-  // ── The personally computed meal, per size ───────────────────────────
-  //
-  // Both customer sizes are computed through the SAME engine the Anpassar
-  // wizard used (optimizer grams → backend /custom-meal/calculate for
-  // nutrition and öre-precise price), so switching M/L updates grams,
-  // macros and price consistently from the server — never a local UI
-  // multiplication of the personal numbers.
-  const personalMedium = usePersonalizedMeal(meal, "medium");
-  const personalLarge = usePersonalizedMeal(meal, "large");
   const personal = effectiveSize === "large" ? personalLarge : personalMedium;
   const personalData = personal.status === "ready" ? personal.data : null;
   const personalStateFor = (sizeId: string) =>
@@ -407,7 +416,7 @@ export function MealDetailScreen() {
             <ThemedText style={[styles.compactMacro, { color: colors.accent }]}>
               {macros?.proteinG}g protein
             </ThemedText>
-            {!isFixed && (
+            {!isFixed && !personalizedOnly && (
               <>
                 <ThemedText style={styles.compactDot}>·</ThemedText>
                 <ThemedText style={[styles.compactMacro, { opacity: 0.6, fontSize: 11 }]}>
@@ -426,7 +435,7 @@ export function MealDetailScreen() {
 
           {/* ── Full macros ── */}
           <SectionHead>
-            {isFixed
+            {isFixed || personalizedOnly
               ? t("mealDetail.nutrition")
               : `${t("mealDetail.nutrition")} · ${t(`mealDetail.sizeNames.${effectiveSize}`, { defaultValue: effectiveSize })}`}
             {personalData
@@ -468,8 +477,9 @@ export function MealDetailScreen() {
             </ThemedText>
           ) : null}
 
-          {/* ── Size selector (radio rows) — hidden for fixed-portion meals ── */}
-          {!isFixed && (
+          {/* ── Size selector (radio rows) — hidden for fixed-portion meals,
+                 and hidden entirely once a personal portion exists ── */}
+          {!isFixed && !personalizedOnly && (
             <>
               <Divider />
               <SectionHead>{t("mealDetail.chooseSize")}</SectionHead>

--- a/features/menu/personalizedMenu.ts
+++ b/features/menu/personalizedMenu.ts
@@ -21,7 +21,7 @@ import {
   SLOT_TO_MEAL_TIME_TAG,
 } from "@/features/anpassar/optimizer";
 import { mapGoalType } from "@/features/anpassar/nutriAnpassarTypes";
-import { MEAL_SIZES } from "@/utils/pricing";
+import { savedPlanTargets } from "@/features/dayplan/dayPlanSlots";
 
 
 /**
@@ -44,14 +44,29 @@ import { MEAL_SIZES } from "@/utils/pricing";
  *    ingredient sell prices + container cost + minimum floor). The client
  *    never invents a number — it presents the server result.
  *
- * M/L: Anpassar itself always tailored at 1.0×. The menu keeps M and L by
- * scaling the personal TARGET with the established size multipliers
- * (utils/pricing MEAL_SIZES ↔ backend SizeHelper: M=1.0, L=1.2) and
- * re-running the SAME optimize→calculate pipeline per size — so grams,
- * macros and price all come from the server for both sizes, never from a
- * local UI multiplication.
+ * NO SIZE MULTIPLIER ON THE TARGET. The slot target IS the target.
+ * An earlier release scaled it by the M/L macro multiplier (M=1.0, L=1.2)
+ * before optimizing, which meant a card showing "L" silently asked the
+ * optimizer for 120% of the customer's own planned meal — a Lunch target of
+ * 1145 kcal became a 1374 kcal recommendation while Home still promised
+ * 1145. Personalization and portion sizing are two different products; this
+ * module now does only the first, exactly as Anpassar always did (1.0×).
  *
- * CACHE KEYS carry the user id AND a stamp of the scaled target, so:
+ * `sizeId` is therefore no longer part of the computation. It is kept in the
+ * signature so both call sites (which ask for "medium" and "large" to decide
+ * whether L is a real choice) resolve to ONE shared cache row: the two
+ * results are then identical by construction, the existing
+ * arePersonalSizesEquivalent rule sees that, and the L button hides itself.
+ * That is the same mechanism this codebase already used for saturated
+ * recipes — no second, competing way to hide a size.
+ *
+ * THE TARGET IS THE ONE THE CUSTOMER WAS SHOWN. `todayMeals` comes from
+ * savedPlanTargets() — the same derivation Home's HomeDayPlan and the menu's
+ * SlotTargetBanner render from — and the slot may be passed in by the caller
+ * so a tap on "Middag" at 12:00 optimizes against Middag, not against
+ * whatever the clock would have guessed.
+ *
+ * CACHE KEYS carry the user id AND a stamp of the target, so:
  *  - two users on one device can never see each other's numbers,
  *  - any profile/goal/override change flows through the shared ["nutrition"]
  *    queries, changes the target, and thereby keys fresh computations —
@@ -117,28 +132,26 @@ function useContainerTypesQuery() {
   });
 }
 
-function scaleTarget(target: ApiMealDistribution, multiplier: number): ApiMealDistribution {
-  if (multiplier === 1) return target;
-  return {
-    ...target,
-    calories: Math.round(target.calories * multiplier),
-    proteinG: Math.round(target.proteinG * multiplier),
-    carbsG: Math.round(target.carbsG * multiplier),
-    fatG: Math.round(target.fatG * multiplier),
-  };
-}
-
 /**
- * The personally computed version of one meal at one size.
+ * The personally computed version of one meal, against the customer's own
+ * slot target — no size scaling of any kind.
  *
  * Safe to call from every card: the heavy inputs are shared React Query
  * entries, and the per-meal computation is itself cached under a key that
- * includes user, target and size.
+ * includes user and target.
+ *
+ * @param sizeId  Retained for call-site compatibility only — see the module
+ *   comment. It deliberately does NOT influence the target or the cache key.
+ * @param slotOverride  The day-plan slot the customer navigated from, when
+ *   the caller knows it. Without it the slot is inferred from the meal's
+ *   tags and the clock, which cannot tell Lunch from Middag at midday.
  */
 export function usePersonalizedMeal(
   meal: ApiMeal | null | undefined,
   sizeId: string,
+  slotOverride: WizardSlot | null = null,
 ): PersonalizedMealState {
+  void sizeId;
   const { user } = useAuth();
   const todayQuery = useTodayNutritionQuery();
   const dayPlanQuery = useTodayDayPlanQuery();
@@ -147,7 +160,10 @@ export function usePersonalizedMeal(
   const containersQuery = useContainerTypesQuery();
 
   const nowHour = new Date().getHours();
-  const slot = meal ? slotForMeal(meal, nowHour) : null;
+  // The navigated slot wins: it is what Home showed and what
+  // SlotTargetBanner is displaying. The tag/clock inference is the fallback
+  // for screens reached without slot context (deep link, back-navigation).
+  const slot = meal ? (slotOverride ?? slotForMeal(meal, nowHour)) : null;
 
   const applicable =
     !!user &&
@@ -165,30 +181,33 @@ export function usePersonalizedMeal(
 
   // The saved day plan wins over the auto-calculated day — the exact rule
   // the Anpassar wizard applies.
+  //
+  // Read through savedPlanTargets, NOT off the stored rows: in 3-meal mode
+  // the snack is dropped and its calories are scaled back into the three
+  // main meals, so the stored row and the row Home/SlotTargetBanner DISPLAY
+  // are deliberately different numbers. Optimizing against the stored row
+  // would tailor the meal to a target the customer was never shown — the
+  // same class of bug mealRecommendation.ts already fixed for size picking.
+  const savedVisible = savedPlanTargets(dayPlanQuery.data);
   const effectiveMeals: ApiMealDistribution[] =
-    today && dayPlanQuery.data?.meals?.length
-      ? dayPlanQuery.data.meals.map((m) => ({
+    today && savedVisible.length > 0
+      ? savedVisible.map((m) => ({
           ...m,
           timingPurpose: today.meals.find((t) => t.label === m.label)?.timingPurpose ?? "",
         }))
       : (today?.meals ?? []);
 
-  const sizeMultiplier = MEAL_SIZES.find((s) => s.id === sizeId)?.macroMultiplier ?? 1;
-
   const target =
     applicable && today && remaining && effectiveMeals.length > 0
-      ? scaleTarget(
-          buildNutriAdaptiveTarget({
-            selectedSlot: slot!,
-            nowHour,
-            goalType: mapGoalType(today.primaryGoal),
-            todayMeals: effectiveMeals,
-            remaining: remaining.remainingToday,
-            consumedToday: remaining.consumedToday,
-            dailyCalories: today.adjustedTarget.calories,
-          }),
-          sizeMultiplier,
-        )
+      ? buildNutriAdaptiveTarget({
+          selectedSlot: slot!,
+          nowHour,
+          goalType: mapGoalType(today.primaryGoal),
+          todayMeals: effectiveMeals,
+          remaining: remaining.remainingToday,
+          consumedToday: remaining.consumedToday,
+          dailyCalories: today.adjustedTarget.calories,
+        })
       : null;
 
   const targetStamp = target
@@ -196,10 +215,10 @@ export function usePersonalizedMeal(
     : null;
 
   const personalQuery = useQuery({
-    // User id + target stamp + meal + size: a profile change produces a new
-    // stamp (fresh computation), and another account can never hit this
-    // cache entry.
-    queryKey: ["personal-meal", user?.id ?? null, targetStamp, meal?.id ?? null, sizeId],
+    // User id + target stamp + meal. NO sizeId: the size no longer changes
+    // the computation, so both size call sites share this one row — one
+    // calculate request per card instead of two identical ones.
+    queryKey: ["personal-meal", user?.id ?? null, targetStamp, meal?.id ?? null],
     enabled:
       applicable &&
       !profileGap &&

--- a/scripts/check-ingredient-limits.mjs
+++ b/scripts/check-ingredient-limits.mjs
@@ -77,15 +77,24 @@ check(`MinAmountG respekteras (kyckling ${minned.prot} ≥ 80)`, minned.prot >= 
 check(`MinAmountG respekteras (puré ${minned.carb} ≥ 100)`, minned.carb >= 100);
 
 // ── 3. NULL = the historical 0/500 fallback, unchanged ──────────────────
-const fallback = amounts(optimizeIngredients(recipe, lib(null), bigTarget));
+// Needs a target that genuinely asks for more than 250 g of protein source.
+// Under the residual model the protein role only covers what the rest of the
+// meal leaves behind, so bigTarget's 60 P is met at ~168 g — that is the fit
+// working, not the cap moving. 90 P is what actually probes the ceiling.
+const proteinHeavyTarget = { ...bigTarget, calories: 1800, proteinG: 90 };
+const fallback = amounts(optimizeIngredients(recipe, lib(null), proteinHeavyTarget));
 check(`NULL-fallback tillåter > 250 (kyckling ${fallback.prot})`, fallback.prot > 250);
 check(`NULL-fallback stannar vid 500 (puré ${fallback.carb} ≤ 500)`, fallback.carb <= 500);
 
 // ── 4. Saturated M and L are identical → equivalence collapses them ─────
+// Same limits as before; the target pair is raised so BOTH sizes really do
+// saturate. At bigTarget the residual fit now lands M below the protein cap,
+// so that pair no longer tests saturation at all.
 const sat = { prot: [80, 200], carb: [100, 250] };
-const satM = optimizeIngredients(recipe, lib(sat), bigTarget);
+const satM = optimizeIngredients(recipe, lib(sat),
+  { ...bigTarget, calories: 2000, proteinG: 100, carbsG: 300, fatG: 40 });
 const satL = optimizeIngredients(recipe, lib(sat),
-  { ...bigTarget, calories: 1680, proteinG: 72, carbsG: 240, fatG: 36 });
+  { ...bigTarget, calories: 2400, proteinG: 120, carbsG: 360, fatG: 48 });
 check("mättade M/L blir ekvivalenta → L döljs",
   areCustomMealPortionsEquivalent({ ingredients: satM }, { ingredients: satL }));
 

--- a/utils/cartMath.ts
+++ b/utils/cartMath.ts
@@ -53,6 +53,14 @@ export function getItemMacros(
  */
 export function getItemWeightG(item: CartItem): number {
   if (item.kind === "drink") return 0;
+  // A custom/personalized line's grams ARE the optimizer's output — the
+  // recipe amounts are not what was ordered, and no size multiplier applies
+  // (the backend stores these grams verbatim with Size = "medium"). Scaling
+  // them by a leftover sizeId was a size multiplier on a personalized line.
+  if (item.isCustom && item.customIngredients) {
+    const customGrams = item.customIngredients.reduce((sum, ing) => sum + (ing.amountG ?? 0), 0);
+    return customGrams * item.quantity;
+  }
   const size = MEAL_SIZES.find((s) => s.id === item.sizeId);
   const mult = size?.macroMultiplier ?? 1;
   const baseGrams = item.meal.ingredients.reduce((sum, ing) => sum + (ing.amountG ?? 0), 0);


### PR DESCRIPTION
Personliga måltider styrs nu av kundens slot-target hela vägen, och storleksväljaren försvinner när en personlig portion finns.

## Vad ändras

**Target propagation**
- Home-slotens target är source of truth — navigations-sloten vinner över tagg-/klockgissning.
- Ingen personalized sizeMultiplier: den personliga queryn är inte längre size-driven (queryKey utan sizeId).

**Optimizer**
- kcal jagas inte längre separat; det faller ut ur 4P + 4C + 9F.
- Residualmodell: fixed-ingredienser räknas som konstanter → proteinpass → carbpass → kort andra proteinpass → STOPP.
- Ingen global kcal-rescale, ingen fat→protein-swap, ingen konvergensloop.
- `Frukt` → `fixed`: bär och banan är smak och receptidentitet, inte en carb-källa att blåsa upp.
- Korrekt clamp-redistribution: en rollmedlem som slår i min/max pinnas på gränsen och blir konstant, residualen räknas om och fördelas på dem som fortfarande är fria. Alla min/max respekteras.

**Personalized-only**
- När personalisering är `ready` visas endast den anpassade portionen: ingen M/L-väljare, ingen "rekommenderad L", ingen storlekscopy.
- M/L finns kvar som fallback när personalisering inte är giltig (utloggad, ofullständig profil, fixed portion, meal utan länkade ingredienser).
- Constraint-limited resultat är fortfarande personalized — det faller aldrig tillbaka till M/L bara för att target inte nås exakt.

**Cart**
- Personliga rader lagras med neutral `sizeId: "medium"` (metadata; backend hårdkodar samma värde för custom-rader).
- Vikt och gram för custom-rader kommer från `customIngredients`, inte recept × storleksmultiplikator.
- Makros och pris kommer som förut från `customMacros`/`customPriceOre` (backendens calculate).
- Ingen M/L-pill på en personlig rad.
- Varje personlig add får eget UUID och dedupas aldrig — samma måltid i Lunch och Middag ligger som två rader med olika gram.

**Backend ändrades inte.** Read-only verifierat: custom-rader räknas om server-side från exakta gram, och `Size = "medium"` är legacy-metadata, inte beräkningsinput.

## Verifiering

`npx tsc --noEmit` pass · `npm run lint` 0 problem · samtliga 21 guards gröna (limits, sizes, pricing, dayplan, dayplanorder, nutritionui, final5 m.fl.).

Regression körd mot riktig staging-data för Beef Power Bowl och Chicken Sweet Potato Bowl, mot både live-target och ett litet ~600 kcal-target. Constraint-limited fall rapporteras som constraint-limited i stället för att kompenseras med mer protein.

## Kända uppföljningar — INTE fixade här

- **Web-optimizern kör fortfarande gamla kcal-jagande modellen** och är kundnåbar via `/nutri-anpassar` och `/heldag`. Samma kund kan få andra gram på webben än i appen.
- **Spanish Beef Bowl / Spanish Chicken Bowl finns inte i staging-datan** — optimizern är ännu inte verifierad mot de rätter kunden faktiskt köper i produktion. Kvarstår som launch-QA.
- **Slot sparas inte i order-snapshoten** — `OrderLine` har inget slot-fält och payloaden skickar det inte.
- **Sex seed-meals med `ingredientId: null` på samtliga rader** är `available: true` i staging. De personaliseras inte (gaten fångar dem) men bör granskas i admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)