### PR TITLE
fix: align macro adjust protein targets

### DIFF
--- a/features/profile/MacroAdjustScreen.tsx
+++ b/features/profile/MacroAdjustScreen.tsx
@@ -28,7 +28,6 @@ import {
 } from "@/services/api/nutrition";
 import { formatNumber, useLanguage, useTranslation } from "@/i18n";
 import { colors, fontFamily, spacing } from "@/theme";
-import { mapBodyFat } from "./profileOptions";
 
 /**
  * Justera makros — port of the web's app/profil/justera-makros/page.tsx.
@@ -36,8 +35,9 @@ import { mapBodyFat } from "./profileOptions";
  * draft committed on blur, macro sliders/steppers (±5g; protein max 350,
  * carbs 600, fat 200), balance rule (macro kcal within 95–105% of target
  * AND |diff| ≤ 50 to save), the recalc CTA that resizes macros for a new
- * kcal target (protein per-kg by goal with lean-mass/BMI-25 base and
- * planFocus adjustments — mirrors NutritionEngineService), override
+ * kcal target (protein per-kg by goal on a BMI-25-capped body-weight base
+ * with a 1.6 g/kg floor and planFocus adjustments — mirrors
+ * NutritionEngineService), override
  * save/reset through PUT/DELETE /nutrition-profile/override, and the
  * Nutri-recommendation line (result when Auto, preview of the stored
  * profile when overridden).
@@ -63,8 +63,6 @@ export function MacroAdjustScreen() {
 
   const [weightKg, setWeightKg] = useState(0);
   const [heightCm, setHeightCm] = useState(0);
-  const [bodyFatLevel, setBodyFatLevel] = useState<number | null>(null);
-  const [gender, setGender] = useState("");
   const [planFocus, setPlanFocus] = useState<string | null>(null);
 
   const [userKcal, setUserKcal] = useState(0);
@@ -106,8 +104,6 @@ export function MacroAdjustScreen() {
       if (np) {
         setWeightKg(np.weightKg);
         setHeightCm(np.heightCm);
-        setBodyFatLevel(np.bodyFatLevel);
-        setGender(np.gender);
         setPlanFocus(np.planFocus ?? null);
       }
 
@@ -217,11 +213,13 @@ export function MacroAdjustScreen() {
     const goal = result.primaryGoal;
     const proteinPerKg = goal === "FatLoss" ? 2.2 : goal === "MuscleGain" ? 2.0 : 1.8;
 
+    // Protein base weight: actual body weight, with a BMI-25 cap above BMI 27.
+    // bodyFatLevel deliberately does NOT lower this base — it drives BMR only,
+    // server-side. Basing protein on lean mass collapsed the target (a 70 kg
+    // MuscleGain profile dropped 140 g → 101 g just by answering the body-fat
+    // question).
     let proteinBaseWeight = weightKg;
-    const bfPct = mapBodyFat(bodyFatLevel, gender);
-    if (bfPct !== null) {
-      proteinBaseWeight = weightKg * (1 - bfPct);
-    } else if (heightCm > 0) {
+    if (heightCm > 0) {
       const heightM = heightCm / 100;
       const bmi = weightKg / (heightM * heightM);
       if (bmi >= 27) {
@@ -240,6 +238,10 @@ export function MacroAdjustScreen() {
       proteinG = Math.max(proteinG * 0.95, 1.6 * proteinBaseWeight);
       fatG *= 1.1;
     }
+
+    // Absolute protein floor — 1.6 g per kg actual body weight. Applied after
+    // planFocus so Health (×0.95) can never push protein under it.
+    proteinG = Math.max(proteinG, 1.6 * weightKg);
 
     const newProtein = Math.round(proteinG);
     const newFat = Math.round(fatG);


### PR DESCRIPTION
Client-side parity fix for backend [Nutri-Backend#35](https://github.com/OscarLrsen/Nutri-Backend/pull/35). Mobile only — one file, one function.

## Problem

`MacroAdjustScreen.recalcMacros()` still implemented the pre-#35 protein rule:

```ts
if (bfPct !== null) proteinBaseWeight = weightKg * (1 - bfPct);   // LBM
else if (bmi >= 27) proteinBaseWeight = min(weightKg, hM² * 25);  // cap unreachable with bodyfat
```

with no absolute floor. So the moment a user had answered the body-fat question, pressing "Räkna om" produced a different protein target than the server: 101 g vs the backend's 140 g for a 70 kg MuscleGain profile.

Initial values were never wrong — they come from `getNutritionResult()`. Only the recalc path diverged.

## Why local math at all

`recalcMacros` resizes macros for a **user-chosen** kcal target. No backend endpoint accepts an arbitrary kcal target — `preview` derives its own from TDEE — so this one function genuinely needs local math. It now mirrors the backend rule exactly rather than being restructured.

## Rule after the fix

```ts
proteinBaseWeight = bmi >= 27 ? min(weightKg, heightM² * 25) : weightKg
proteinG          = proteinBaseWeight * coefficient          // 2.2 / 1.8 / 2.0
// planFocus adjustments (unchanged)
proteinG          = Math.max(proteinG, 1.6 * weightKg)       // floor, after planFocus
```

`bodyFatLevel` and `gender` state were removed from this screen — they had no remaining reader. `bodyFatLevel` still reaches the server in the preview payload, and still drives BMR there.

## Parity

Protein block extracted from the patched source and evaluated against the backend rule — exact integer match, no rounding divergence:

| Profil | Backend | Mobile | Klient före |
|---|---|---|---|
| 70 kg K, 170 cm, MuscleGain, bodyfat 3 | 140 g | 140 g | 101 g |
| 70 kg K, 170 cm, MuscleGain, utan bodyfat | 140 g | 140 g | 140 g |
| 90 kg M, 185 cm, FatLoss, bodyfat 4 | 198 g | 198 g | 154 g |
| 120 kg M, 175 cm, FatLoss (BMI-cap) | 192 g | 192 g | 168 g |
| 110 kg M, 175 cm, Maintain (cap < golv) | 176 g | 176 g | 138 g |
| 100 kg K, 160 cm, Maintain, Health | 160 g | 160 g | 109 g |

## Not changed

kcal stepper and clamp, fat formula, carb residual, balance rule, slider/stepper ranges, the override contract (`PUT`/`DELETE /nutrition-profile/override`), Home, day plan, meal optimizer, `profileOptions.mapBodyFat` (still exported and used for the profile UI).

`recalcMacros` remains reachable only from the explicit CTA (`onPress`, gated by `needsRecalc`) — a manually chosen protein value is never silently replaced.

## Verification

`npx tsc --noEmit` → exit 0 · `npm run lint` → exit 0 · guard scripts `i18n:check`, `profile:check`, `profilescroll:check`, `nutritionui:check`, `dayplan:check`, `dayplanedit:check`, `final5:check` → all exit 0.

Not verified in a running simulator — reported as unverified rather than claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)