### PR TITLE
fix: align macro adjust fat targets

### DIFF
--- a/features/profile/MacroAdjustScreen.tsx
+++ b/features/profile/MacroAdjustScreen.tsx
@@ -228,7 +228,12 @@ export function MacroAdjustScreen() {
     }
 
     let proteinG = proteinBaseWeight * proteinPerKg;
-    let fatG = Math.max(0.6 * weightKg, 40);
+
+    // Fat floor: the highest of 0.6 g/kg actual body weight, a 20% share of the
+    // kcal target, and an absolute 40 g. The calorie share stops fat flat-lining
+    // at high kcal targets, where every extra kcal used to land in carbs.
+    const fatFloor = Math.max(Math.max(0.6 * weightKg, (userKcal * 0.2) / 9), 40);
+    let fatG = fatFloor;
 
     if (planFocus === "Satiety") {
       fatG *= 1.1;
@@ -242,6 +247,10 @@ export function MacroAdjustScreen() {
     // Absolute protein floor — 1.6 g per kg actual body weight. Applied after
     // planFocus so Health (×0.95) can never push protein under it.
     proteinG = Math.max(proteinG, 1.6 * weightKg);
+
+    // Fat floor re-applied after planFocus so Performance can still trim fat,
+    // but never below 20% of the kcal target (or the weight/absolute floors).
+    fatG = Math.max(fatG, fatFloor);
 
     const newProtein = Math.round(proteinG);
     const newFat = Math.round(fatG);


### PR DESCRIPTION
Client parity for backend [Nutri-Backend#36](https://github.com/OscarLrsen/Nutri-Backend/pull/36). Mobile only — one file, the `recalcMacros` fat block.

## Problem

The recalc CTA floored fat at `max(0.6 * weightKg, 40)`, independent of the kcal target. At high targets fat flat-lined and every extra kcal went to carbs — a 3560 kcal plan produced 57 g fat, 14.4% of energy.

## Rule after the fix

```ts
const fatFloor = Math.max(Math.max(0.6 * weightKg, (userKcal * 0.2) / 9), 40);
let fatG = fatFloor;
// planFocus adjustments (unchanged)
fatG = Math.max(fatG, fatFloor);   // Performance may trim, never below the floor
```

## Parity

Macro block extracted from the patched source and evaluated against the backend rule:

| Test | Profil | Backend P/C/F | Mobile P/C/F | fat% |
|---|---|---|---|---|
| T1 | 3560 kcal, 95 kg, MuscleGain | 190/522/79 | **190/522/79** | 20.0 |
| T2 | 2000 kcal, 70 kg | 126/275/44 | **126/275/44** | 19.8 |
| T3 | 2000 kcal, 90 kg | 162/217/54 | **162/217/54** | 24.3 |
| T4 | 1200 kcal, 45 kg | 99/111/40 | **99/111/40** | 30.0 |
| T5 | 4000 kcal, 80 kg | 160/640/89 | **160/640/89** | 20.0 |
| T6 | 3560 kcal, 95 kg, Performance | 190/522/79 | **190/522/79** | 20.0 |
| T7a | 2400 kcal, 100 kg, Satiety | 162/290/66 | **162/290/66** | 24.8 |
| T7b | 2400 kcal, 100 kg, Health | 160/292/66 | **160/292/66** | 24.8 |

Across a 2304-combination sweep against the backend arithmetic: **protein 0 deviations, fat 0 deviations**. Carbs differ on 569 combinations by at most **2 g (8 kcal)** — a pre-existing rounding-order difference (the C# engine derives the residual from unrounded doubles; the client rounds protein and fat first). Not introduced here, but more visible now that fat is often fractional. It sits far inside the screen's own ±50 kcal balance rule, so it is reported rather than fixed — changing the client's rounding order would touch the manual-adjust integer contract.

## Manual override preserved (T8)

`recalcMacros` is still reachable only from the explicit CTA (`onPress`, gated by `needsRecalc`); no `useEffect` calls it. A manually chosen fat value is never overwritten. The ± steppers, sliders, save/reset and the `PUT`/`DELETE /nutrition-profile/override` contract are untouched, and initial values still come from the server.

## Verification

`npx tsc --noEmit` → exit 0 · `npm run lint` → exit 0 · guards `i18n:check`, `profile:check`, `profilescroll:check`, `nutritionui:check`, `dayplan:check`, `dayplanedit:check`, `final5:check` → all exit 0.

Not verified in a running simulator — reported as unverified rather than claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)