### PR TITLE
fix: stop optimizer at macro target

### DIFF
--- a/features/anpassar/buildNutriAdaptiveTarget.ts
+++ b/features/anpassar/buildNutriAdaptiveTarget.ts
@@ -70,7 +70,24 @@ export function buildNutriAdaptiveTarget(input: NutriAdaptiveTargetInput): ApiMe
   // ── F. HARD CAPS ─────────────────────────────────────────────────────
   const { min: mealMin, max: mealMax } = getMealCaps(goalType, dailyCalories);
   // profileCap = dailyCalories; HARD_CAP_KCAL already baked into getMealCaps.
-  targetCalories = Math.max(mealMin, Math.min(targetCalories, mealMax));
+  //
+  // The MAX cap always applies — no single meal may be recommended above it.
+  // The MIN floor must not: it is a rescue for a baseline this function
+  // DERIVED (fallbackBaseline's share-of-remaining), never a licence to
+  // overwrite a slot the customer actually planned.
+  //
+  // What the floor did to a planned slot: on a 4917 kcal day (muscle_gain →
+  // min = 25% = 1229) a planned 824 kcal snack was lifted to 1229, and since
+  // carbs/fat are scaled by targetCalories / baseline.calories just below,
+  // 118 g carbs became 176 g. The optimizer then correctly drove the carb
+  // base to its admin max to meet that 176 g — serving ~1015 kcal for a slot
+  // Home had promised as 824. That contradicts C/D above: "Sätt upp din dag"
+  // is source of truth, used as-is, with no goal-based drift.
+  //
+  // A planned slot that genuinely is tiny is still rescued by the low-target
+  // fallback in G, which is the branch that exists for that case.
+  targetCalories = Math.min(targetCalories, mealMax);
+  if (!planned) targetCalories = Math.max(mealMin, targetCalories);
 
   // Scale carbs/fat proportionally; protein is bounded from below.
   const calorieRatio = baseline.calories > 0 ? targetCalories / baseline.calories : 1;

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "pricing:check": "node scripts/check-custom-meal-pricing.mjs",
     "sizes:check": "node scripts/check-portion-sizes.mjs",
     "limits:check": "node scripts/check-ingredient-limits.mjs",
+    "slottarget:check": "node scripts/check-slot-target-fidelity.mjs",
     "feedback:check": "node scripts/check-food-feedback.mjs",
     "snags:check": "node scripts/check-oscar-snags.mjs",
     "profile:check": "node scripts/check-profile-linking-sheets.mjs",

--- a/scripts/check-slot-target-fidelity.mjs
+++ b/scripts/check-slot-target-fidelity.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Slot-target fidelity: the meal the app builds is the meal Home promised.
+ *
+ * WHY THIS EXISTS. "Nutri Anpassar drives adjustable ingredients to their max"
+ * was reported as an optimizer bug. It was not. Given the slot target the
+ * customer was shown, the optimizer already stops at that target and is
+ * already max-invariant. The defect was upstream: getMealCaps' MIN floor
+ * overwrote a PLANNED slot target with dailyCalories × goal%, and because
+ * carbs/fat are then scaled by targetCalories / baseline.calories, the carb
+ * target was inflated with it — on a 4917 kcal muscle_gain day a planned
+ * 824 kcal / 118 C snack became 1229 kcal / 176 C. The optimizer then did the
+ * right thing with the wrong number and pinned the carb base to its admin max.
+ *
+ * So this guard pins BOTH halves of the contract, against the real modules:
+ *
+ *   1. a PLANNED slot target passes through unscaled (no goal-based drift),
+ *   2. the MAX cap still applies (a planned slot cannot exceed it),
+ *   3. the MIN floor still rescues a DERIVED baseline (missing slot),
+ *   4. min/max are CONSTRAINTS, not targets: raising an ingredient's max does
+ *      not change the portion when the target is already met below it,
+ *   5. but a target that genuinely needs more than max still saturates,
+ *   6. fixed-role ingredients keep their recipe grams throughout.
+ *
+ * Fixtures 4–6 use the real production recipe for "Äpple paj CoR med Biscoff"
+ * and the real ingredient rows behind the original report.
+ *
+ * Run: npm run slottarget:check
+ */
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+
+const failures = [];
+const check = (name, ok) => { if (!ok) failures.push(name); };
+
+const outDir = mkdtempSync(join(tmpdir(), "nutri-slottarget-"));
+const transpile = (src, name, fix = (s) => s) => {
+  const js = ts.transpileModule(readFileSync(src, "utf8"), {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 },
+  }).outputText;
+  const p = join(outDir, name);
+  writeFileSync(p, fix(js));
+  return p;
+};
+
+transpile("features/anpassar/nutriAnpassarRules.ts", "nutriAnpassarRules.mjs");
+const { optimizeIngredients } = await import(pathToFileURL(
+  transpile("features/anpassar/optimizer.ts", "optimizer.mjs")).href);
+const { buildNutriAdaptiveTarget } = await import(pathToFileURL(
+  transpile("features/anpassar/buildNutriAdaptiveTarget.ts", "buildNutriAdaptiveTarget.mjs",
+    (s) => s.replace('"./nutriAnpassarRules"', '"./nutriAnpassarRules.mjs"'))).href);
+
+// ── The customer's saved day plan, as Home renders it ───────────────────
+const PLAN = [
+  { label: "Frukost", calories: 989, proteinG: 53, carbsG: 147, fatG: 21, timingPurpose: "" },
+  { label: "Lunch", calories: 1145, proteinG: 53, carbsG: 177, fatG: 25, timingPurpose: "" },
+  { label: "Middag", calories: 976, proteinG: 52, carbsG: 147, fatG: 20, timingPurpose: "" },
+  { label: "Mellanmål", calories: 824, proteinG: 52, carbsG: 118, fatG: 16, timingPurpose: "" },
+];
+const SNACK = PLAN[3];
+
+/** muscle_gain on a 4917 kcal day: min = 1229 — above the planned 824. */
+const DAILY = 4917;
+const targetFor = (overrides = {}) =>
+  buildNutriAdaptiveTarget({
+    selectedSlot: "Mellanmål",
+    nowHour: 15,
+    goalType: "muscle_gain",
+    todayMeals: PLAN,
+    remaining: { calories: DAILY, proteinG: 210, carbsG: 589, fatG: 82 },
+    consumedToday: { calories: 500, proteinG: 30, carbsG: 60, fatG: 10 },
+    dailyCalories: DAILY,
+    ...overrides,
+  });
+
+// ── 1. A planned slot target survives the caps unscaled ─────────────────
+const planned = targetFor();
+check(`planerat slot-mål behålls (${planned.calories} kcal = ${SNACK.calories})`,
+  planned.calories === SNACK.calories);
+check(`planerade kolhydrater skalas inte (${planned.carbsG} g = ${SNACK.carbsG})`,
+  planned.carbsG === SNACK.carbsG);
+check(`planerat protein skalas inte (${planned.proteinG} g = ${SNACK.proteinG})`,
+  planned.proteinG === SNACK.proteinG);
+check(`planerat fett skalas inte (${planned.fatG} g = ${SNACK.fatG})`,
+  planned.fatG === SNACK.fatG);
+
+// ── 2. The MAX cap still binds a planned slot ───────────────────────────
+// HARD_CAP_KCAL is 1500; a planned 2400 kcal slot must not survive it.
+const huge = [...PLAN.slice(0, 3), { ...SNACK, calories: 2400, carbsG: 300 }];
+const capped = buildNutriAdaptiveTarget({
+  selectedSlot: "Mellanmål", nowHour: 15, goalType: "muscle_gain", todayMeals: huge,
+  remaining: { calories: DAILY, proteinG: 210, carbsG: 589, fatG: 82 },
+  consumedToday: { calories: 500, proteinG: 30, carbsG: 60, fatG: 10 }, dailyCalories: DAILY,
+});
+check(`MAX-cap gäller fortfarande (${capped.calories} ≤ 1500)`, capped.calories <= 1500);
+check(`MAX-cap skalar ned kolhydraterna med (${capped.carbsG} < 300)`, capped.carbsG < 300);
+
+// ── 3. The MIN floor still rescues a DERIVED baseline ───────────────────
+// Slot missing from the plan → fallbackBaseline, which the floor may lift.
+const derived = buildNutriAdaptiveTarget({
+  selectedSlot: "Mellanmål", nowHour: 15, goalType: "muscle_gain",
+  todayMeals: PLAN.slice(0, 3),
+  remaining: { calories: 900, proteinG: 60, carbsG: 120, fatG: 20 },
+  consumedToday: { calories: 500, proteinG: 30, carbsG: 60, fatG: 10 }, dailyCalories: DAILY,
+});
+check(`MIN-golvet räddar fortfarande ett härlett mål (${derived.calories} ≥ ${Math.round(DAILY * 0.25)})`,
+  derived.calories >= Math.round(DAILY * 0.25));
+
+// ── 4–6. Real recipe: max is a constraint, not a destination ────────────
+const LIB = (riceMax) => [
+  { id: "apple", name: "Äpplen med Kanel", category: "Övriga",
+    calories100g: 52, proteinG100g: 0.3, carbsG100g: 12, fatG100g: 0.2,
+    minAmountG: 50, maxAmountG: 80 },
+  { id: "biscoff", name: "Biscoff", category: "Övriga",
+    calories100g: 484, proteinG100g: 4.9, carbsG100g: 72.6, fatG100g: 19,
+    minAmountG: 10, maxAmountG: 20 },
+  { id: "rice", name: "Rismjöl", category: "Kolhydrater",
+    calories100g: 352, proteinG100g: 6.5, carbsG100g: 79, fatG100g: 1,
+    minAmountG: 35, maxAmountG: riceMax },
+  { id: "whey", name: "Vassleprotein Vanilj", category: "Protein",
+    calories100g: 395, proteinG100g: 75, carbsG100g: 8.2, fatG100g: 6.9,
+    minAmountG: 20, maxAmountG: 60 },
+];
+const RECIPE = [
+  { ingredientId: "apple", name: "Äpplen med Kanel", amountG: 50 },
+  { ingredientId: "biscoff", name: "Biscoff", amountG: 10 },
+  { ingredientId: "rice", name: "Rismjöl", amountG: 50 },
+  { ingredientId: "whey", name: "Vassleprotein Vanilj", amountG: 30 },
+];
+const gramsAt = (riceMax, target) =>
+  Object.fromEntries(optimizeIngredients(RECIPE, LIB(riceMax), target).map((i) => [i.ingredientId, i.amountG]));
+
+// 4. Raising max must not raise the portion when the target is met below it.
+const at150 = gramsAt(150, planned);
+const at200 = gramsAt(200, planned);
+check(`rice max 150→200 ändrar inte portionen (${at150.rice} vs ${at200.rice})`,
+  at150.rice === at200.rice);
+check(`rice stannar under 150 när målet nås där (${at150.rice} < 150)`, at150.rice < 150);
+check(`whey går inte automatiskt till max (${at150.whey} < 60)`, at150.whey < 60);
+
+// 5. A target that truly needs more than max still saturates.
+const hungry = { label: "Mellanmål", calories: 1400, proteinG: 60, carbsG: 260, fatG: 24, timingPurpose: "" };
+check(`max fungerar fortfarande som constraint (${gramsAt(150, hungry).rice} = 150)`,
+  gramsAt(150, hungry).rice === 150);
+check(`höjt max används när målet kräver det (${gramsAt(200, hungry).rice} = 200)`,
+  gramsAt(200, hungry).rice === 200);
+
+// 6. Fixed-role ingredients never move.
+check(`äpple låst på recept-gram (${at200.apple} = 50)`, at200.apple === 50);
+check(`biscoff låst på recept-gram (${at200.biscoff} = 10)`, at200.biscoff === 10);
+
+// ── Rapport ─────────────────────────────────────────────────────────────
+if (failures.length > 0) {
+  console.error("✗ Slot target fidelity guard failed:\n");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log("✓ Måltiden som byggs är måltiden Home lovade:");
+console.log(`    planerat slot-mål passerar caps oskalat (${planned.calories} kcal / ${planned.carbsG} C)`);
+console.log("    MAX-cap gäller fortfarande; MIN-golvet räddar bara härledda mål");
+console.log(`    rice max 150 vs 200 ger samma portion (${at150.rice} g) — max är constraint, inte mål`);
+console.log("    men ett mål som kräver mer än max mättar fortfarande");
+console.log("    fixed-roll (äpple, biscoff) står kvar på recept-gram");


### PR DESCRIPTION
## What was reported

Nutri Anpassar appeared to drive adjustable ingredients to their **max** instead of stopping when the meal's macro target was met. On *Äpple paj CoR med Biscoff* with a Mellanmål target of `824 kcal / 52P / 118C / 16F`, rice landed on 150 g when its max was 150, and on exactly 200 g when the max was raised to 200 — giving `1015 kcal / 59P / 176C / 8F`.

## Root cause — not the optimizer

Given the slot target the customer was shown, the optimizer already stops at target and is already max-invariant. Against the real recipe at `824/52/118/16` it returns **126 g rice whether the max is 150 or 200**.

The **target handed to it** was wrong. In `buildNutriAdaptiveTarget` section F, the `getMealCaps` **MIN floor** was applied to every baseline — including a slot the customer had actually planned:

| step | before |
|---|---|
| planned Mellanmål (what Home shows) | `824 kcal / 52P / 118C / 16F` |
| `mealMin` = dailyCalories 4917 × 0.25 (muscle_gain) | `1229` |
| line 73 floor raises calories | `824 → 1229` |
| `calorieRatio` | `1.49` |
| line 88 scales carbs by it | `118 → 176 g` |
| optimizer meets 176 g carbs | carb base pinned to admin max |

So the optimizer did exactly the right thing with the wrong number, and raising the rice max moved the portion 150 → 200 for the same reason.

This also contradicted the invariant stated in the same function at C/D: *"Sätt upp din dag är source of truth — slot target is used as-is, no goal-based drift applied."*

## The fix

One line split in two. The **MAX cap still always applies**. The **MIN floor now applies only when this function derived the baseline itself** (`fallbackBaseline`'s share-of-remaining, when the slot is missing from the plan) — the case it exists for. A planned slot that genuinely is tiny is still rescued by the low-target fallback in section G.

**The optimizer is untouched** — role grouping, both residual passes, FREE/CLAMPED redistribution and all min/max handling are unchanged.

## Before / after — Cream of Rice

Home shows `824 kcal / 52P / 118C / 16F`.

| | target passed to optimizer | rice max 150 | rice max 200 |
|---|---|---|---|
| **before** | `1229 / 78P / 176C / 24F` | rice **150**, whey 60 → `839 kcal / 55P / 137C / 8F` | rice **200**, whey 60 → `1015 kcal / 59P / 176C / 8F` |
| **after** | `824 / 52P / 118C / 16F` | rice **126**, whey 58 → `747 kcal / 52P / 118C / 7F` | rice **126**, whey 58 → `747 kcal / 52P / 118C / 7F` |

Raising the max no longer changes the portion. Whey stops at 58 g, below its 60 g max. Apple stays 50 g and Biscoff 10 g throughout.

Constraint behaviour is preserved: a target that genuinely needs more than max still saturates (verified at `1400 kcal / 260C` → rice 150 at max 150, 200 at max 200).

## Main-meal regression

Main meals improve — protein now lands on the planned slot value instead of the inflated one, and Chicken Sweet Potato Bowl is no longer pinned at its 300 g chicken max:

| slot | meal | before | after |
|---|---|---|---|
| Lunch (`1145/53P`) | Beef Power Bowl | beef 199, keso 50 → 57P | beef 182, keso 45 → **53P** |
| Lunch | Chicken Sweet Potato | chick 267 → 57P | chick 245 → **53P** |
| Middag (`976/52P`) | Beef Power Bowl | beef 233, keso 58 → 65P | beef 178, keso 44 → **52P** |
| Middag | Chicken Sweet Potato | chick **300 (MAX)** → 63P | chick 239 → **52P** |

Multi-member clamp redistribution still works (Beef's keso + beef scale together, neither pinned). Sweet potato sits at its 350 g max before and after — genuine saturation against a 147–177 g carb target, unchanged.

## New guard

`npm run slottarget:check` (`scripts/check-slot-target-fidelity.mjs`) pins both halves against the real modules: a planned slot target survives the caps unscaled, the MAX cap still binds, the MIN floor still rescues a derived baseline, raising an ingredient max does not move a portion that already met its target, a target that truly needs more than max still saturates, and fixed-role ingredients keep their recipe grams.

It **fails on the pre-fix code** with exactly the reported symptoms:

```
- planerat slot-mål behålls (1229 kcal = 824)
- planerade kolhydrater skalas inte (176 g = 118)
- rice max 150→200 ändrar inte portionen (150 vs 200)
- whey går inte automatiskt till max (60 < 60)
```

## Verification

- `npx tsc --noEmit` — exit 0
- `npm run lint` — exit 0
- all **22** guard scripts pass (21 existing + the new one)

## Not touched

Optimizer, Home, slot distribution, pricing, cart, checkout, backend, admin, migrations, the CoR recipe data and all ingredient min/max data are unchanged. No admin min/max was altered to mask the behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)